### PR TITLE
Rework native functions

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -16,11 +16,10 @@ use std::{
     ops::Range,
 };
 
-use arithmetic_eval::{fns, BacktraceElement, ErrorWithBacktrace, Function, Interpreter, Value};
-use arithmetic_parser::{
-    grammars::{NumGrammar, NumLiteral},
-    Block, Error, Grammar, GrammarExt, Span, Spanned,
+use arithmetic_eval::{
+    fns, BacktraceElement, ErrorWithBacktrace, Function, Interpreter, Number, Value,
 };
+use arithmetic_parser::{grammars::NumGrammar, Block, Error, Grammar, GrammarExt, Span, Spanned};
 
 /// Code map containing evaluated code snippets.
 #[derive(Debug, Default)]
@@ -270,7 +269,7 @@ impl<'a> Env<'a> {
     ) -> Result<bool, ()>
     where
         T: Grammar,
-        T::Lit: fmt::Display + NumLiteral,
+        T::Lit: fmt::Display + Number,
     {
         let (file, start_position) = self.code_map.add(line);
         let visible_span = 0..line.len();
@@ -330,7 +329,7 @@ impl<'a> Env<'a> {
     }
 }
 
-fn init_interpreter<'a, T: NumLiteral>() -> Interpreter<'a, NumGrammar<T>> {
+fn init_interpreter<'a, T: Number>() -> Interpreter<'a, NumGrammar<T>> {
     let mut interpreter = Interpreter::<NumGrammar<T>>::new();
     interpreter
         .insert_var("false", Value::Bool(false))
@@ -345,7 +344,7 @@ fn init_interpreter<'a, T: NumLiteral>() -> Interpreter<'a, NumGrammar<T>> {
     interpreter
 }
 
-pub trait ReplLiteral: NumLiteral + fmt::Display {
+pub trait ReplLiteral: Number + fmt::Display {
     fn create_interpreter<'a>() -> Interpreter<'a, NumGrammar<Self>>;
 }
 
@@ -357,7 +356,7 @@ pub struct StdLibrary<T: 'static> {
     binary: &'static [(&'static str, fn(T, T) -> T)],
 }
 
-impl<T: NumLiteral> StdLibrary<T> {
+impl<T: Number> StdLibrary<T> {
     fn add_to_interpreter(self, interpreter: &mut Interpreter<NumGrammar<T>>) {
         for (name, c) in self.constants {
             interpreter.insert_var(name, Value::Number(*c));

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["interpreter", "arithmetic"]
 
 [dependencies]
 # Public dependencies (present in the public API).
-arithmetic-parser = { version = "0.1.0", path = "../parser" }
+arithmetic-parser = { version = "0.1.0", path = "../parser", features = ["num-complex"] }
 num-traits = "0.2.11"
+num-complex = "0.2.4"
 
 # Private dependencies.
 derive_more = "0.99.7"

--- a/eval/benches/interpreter.rs
+++ b/eval/benches/interpreter.rs
@@ -98,7 +98,7 @@ fn bench_mul_fold(bencher: &mut Bencher<'_>) {
 fn bench_fold_fn(bencher: &mut Bencher<'_>) {
     let mut ctx = CallContext::mock();
     let acc = ctx.apply_call_span(Value::Number(1.0));
-    let fold_fn = fns::Binary::new(|x, y| x * y);
+    let fold_fn = fns::Binary::new(|x: f32, y| x * y);
     let fold_fn = ctx.apply_call_span(Value::native_fn(fold_fn));
 
     let mut rng = StdRng::seed_from_u64(SEED);

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -6,6 +6,7 @@ use core::fmt;
 
 use crate::{
     alloc::{format, vec, String, ToOwned, Vec},
+    fns::FromValueError,
     Value,
 };
 use arithmetic_parser::{create_span_ref, BinaryOp, LvalueLen, Op, Span, Spanned, UnaryOp};
@@ -52,6 +53,7 @@ impl fmt::Display for RepeatedAssignmentContext {
 
 /// Errors that can occur during interpreting expressions and statements.
 #[derive(Debug, Display)]
+#[non_exhaustive]
 pub enum EvalError {
     /// Mismatch between length of tuples in a binary operation or assignment.
     #[display(
@@ -106,6 +108,15 @@ pub enum EvalError {
     #[display(fmt = "Failed executing native function: {}", _0)]
     NativeCall(String),
 
+    /// Error while converting arguments for [`FnWrapper`].
+    ///
+    /// [`FnWrapper`]: fns/struct.FnWrapper.html
+    #[display(
+        fmt = "Failed converting arguments for native function wrapper: {}",
+        _0
+    )]
+    Wrapper(FromValueError),
+
     /// Unexpected operand type for the specified operation.
     #[display(fmt = "Unexpected operand type for {}", op)]
     UnexpectedOperand {
@@ -137,6 +148,7 @@ impl EvalError {
             Self::Undefined(name) => format!("Variable `{}` is not defined", name),
             Self::CannotCall => "Value is not callable".to_owned(),
             Self::NativeCall(message) => message.to_owned(),
+            Self::Wrapper(err) => err.to_string(),
             Self::UnexpectedOperand { op } => format!("Unexpected operand type for {}", op),
         }
     }
@@ -151,7 +163,7 @@ impl EvalError {
             Self::CannotDestructure => "Failed destructuring".to_owned(),
             Self::RepeatedAssignment { .. } => "Re-assigned variable".to_owned(),
             Self::Undefined(_) => "Undefined variable occurrence".to_owned(),
-            Self::CannotCall | Self::NativeCall(_) => "Failed call".to_owned(),
+            Self::CannotCall | Self::NativeCall(_) | Self::Wrapper(_) => "Failed call".to_owned(),
             Self::UnexpectedOperand { .. } => "Operand of wrong type".to_owned(),
         }
     }

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -257,6 +257,11 @@ impl<'a> SpannedEvalError<'a> {
         self.aux_spans.push(create_span_ref(span, info));
         self
     }
+
+    /// Returns the source of the error.
+    pub fn source(&self) -> &EvalError {
+        &self.error
+    }
 }
 
 /// Result of an expression evaluation.

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -437,7 +437,7 @@ where
 /// interpreter
 ///     .insert_native_fn(
 ///         "max",
-///         fns::Binary::new(|x, y| if x > y { x } else { y }),
+///         fns::Binary::new(|x: f32, y: f32| if x > y { x } else { y }),
 ///     )
 ///     .insert_native_fn("fold", fns::Fold)
 ///     .insert_var("INF", Value::Number(f32::INFINITY))

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -440,19 +440,19 @@ where
 ///         fns::Binary::new(|x: f32, y: f32| if x > y { x } else { y }),
 ///     )
 ///     .insert_native_fn("fold", fns::Fold)
-///     .insert_var("INF", Value::Number(f32::INFINITY))
+///     .insert_var("INFINITY", Value::Number(f32::INFINITY))
 ///     .insert_var("xs", Value::Tuple(vec![]));
 ///
-/// let module = "xs.fold(-INF, max)";
+/// let module = "xs.fold(-INFINITY, max)";
 /// let module = F32Grammar::parse_statements(Span::new(module)).unwrap();
 /// let mut module = interpreter.compile(&module).unwrap();
 ///
-/// // With the original imports, the returned value is `-INF`.
+/// // With the original imports, the returned value is `-INFINITY`.
 /// assert_eq!(module.run().unwrap(), Value::Number(f32::NEG_INFINITY));
 ///
 /// // Imports can be changed. Let's check that `xs` is indeed an import.
 /// let imports: HashSet<_> = module.imports().map(|(name, _)| name).collect();
-/// assert_eq!(imports, HashSet::from_iter(vec!["max", "fold", "xs", "INF"]));
+/// assert!(imports.is_superset(&HashSet::from_iter(vec!["max", "fold", "xs"])));
 ///
 /// // Change the `xs` import and run the module again.
 /// let array = [1.0, -3.0, 2.0, 0.5].iter().copied().map(Value::Number).collect();

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -4,20 +4,18 @@
 //!
 //! [`FnWrapper`]: struct.FnWrapper.html
 
-use num_traits::{Num, One, Pow, Zero};
-
-use core::ops;
+use arithmetic_parser::Grammar;
+use num_traits::{One, Zero};
 
 use crate::{
     alloc::{vec, Vec},
-    AuxErrorInfo, CallContext, EvalError, EvalResult, Function, NativeFn, SpannedEvalError,
+    AuxErrorInfo, CallContext, EvalError, EvalResult, Function, NativeFn, Number, SpannedEvalError,
     SpannedValue, Value,
 };
-use arithmetic_parser::Grammar;
 
-mod arity;
-pub use self::arity::{
-    wrap, Binary, ErrorOutput, FnWrapper, Quaternary, Ternary, TryFromValue, TryIntoValue, Unary,
+mod wrapper;
+pub use self::wrapper::{
+    wrap, Binary, ErrorOutput, FnWrapper, IntoEvalResult, Quaternary, Ternary, TryFromValue, Unary,
     WithContext,
 };
 
@@ -161,7 +159,7 @@ pub struct If;
 impl<'a, T> NativeFn<'a, T> for If
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -228,7 +226,7 @@ impl Loop {
 impl<'a, T> NativeFn<'a, T> for Loop
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -312,7 +310,7 @@ pub struct Map;
 impl<'a, T> NativeFn<'a, T> for Map
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -375,7 +373,7 @@ pub struct Filter;
 impl<'a, T> NativeFn<'a, T> for Filter
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -443,7 +441,7 @@ pub struct Fold;
 impl<'a, T> NativeFn<'a, T> for Fold
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -511,7 +509,7 @@ pub struct Push;
 impl<'a, T> NativeFn<'a, T> for Push
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -564,7 +562,7 @@ pub struct Merge;
 impl<'a, T> NativeFn<'a, T> for Merge
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn evaluate(
         &self,
@@ -604,7 +602,7 @@ const COMPARE_ERROR_MSG: &str = "Compare requires 2 primitive arguments";
 impl<'a, T> NativeFn<'a, T> for Compare
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit> + PartialOrd,
+    T::Lit: Number + PartialOrd,
 {
     fn evaluate(
         &self,

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -15,8 +15,8 @@ use crate::{
 
 mod wrapper;
 pub use self::wrapper::{
-    wrap, Binary, ErrorOutput, FnWrapper, IntoEvalResult, Quaternary, Ternary, TryFromValue, Unary,
-    WithContext,
+    wrap, Binary, ErrorOutput, FnWrapper, FromValueError, FromValueErrorKind,
+    FromValueErrorLocation, IntoEvalResult, Quaternary, Ternary, TryFromValue, Unary, WithContext,
 };
 
 fn extract_number<'a, T: Grammar>(

--- a/eval/src/fns/arity.rs
+++ b/eval/src/fns/arity.rs
@@ -1,167 +1,449 @@
-use arithmetic_parser::Grammar;
+use arithmetic_parser::{create_span_ref, Grammar};
 
 use core::{fmt, marker::PhantomData};
 
-use crate::{fns::extract_number, CallContext, EvalResult, NativeFn, SpannedValue, Value};
+use crate::{
+    AuxErrorInfo, CallContext, EvalError, EvalResult, Function, NativeFn, Number, SpannedEvalError,
+    SpannedValue, Value,
+};
 
-/// Arity of a function expressed as a trait.
+/// Wraps a function enriching it with the information about its arguments.
+/// This is a slightly shorter way to create wrappers compared to calling [`FnWrapper::new()`].
 ///
-/// # Implementation details
-///
-/// The necessity of this trait stems from the fact that stable Rust does not so far
-/// support [const generics].
-///
-/// [const generics]: https://github.com/rust-lang/rust/issues/44580
-pub trait Arity {
-    /// Function arity.
-    const ARITY: usize;
+/// [`FnWrapper::new()`]: struct.FnWrapper.html#method.new
+pub const fn wrap<T, F>(function: F) -> FnWrapper<T, F> {
+    FnWrapper::new(function)
 }
 
-/// Wrapper of a function containing information about its arity.
+/// Wrapper of a function containing information about its arguments.
 ///
-/// The instances of this type are created by applying [`WithArity`] trait to a function or closure.
+/// Using `FnWrapper` allows to define [native functions] with minimum boilerplate
+/// and with increased type safety.
 ///
-/// [`WithArity`]: trait.WithArity.html
-#[derive(Debug, Clone, Copy)]
-pub struct FnWrapper<A, F> {
+/// Arguments of a wrapped function should implement [`TryFromValue`] trait for the applicable
+/// grammar, and the output type should implement [`TryIntoValue`]. If the [`CallContext`] is
+/// necessary for execution (for example, if one of args is a [`Function`], which is called
+/// during execution), then it can be specified as the first argument
+/// as shown [below](#usage-of-context).
+///
+/// [native functions]: ../trait.NativeFn.html
+/// [`TryFromValue`]: trait.TryFromValue.html
+/// [`TryIntoValue`]: trait.TryIntoValue.html
+/// [`CallContext`]: ../struct.CallContext.html
+/// [`Function`]: ../enum.Function.html
+///
+/// # Examples
+///
+/// ## Basic function
+///
+/// ```
+/// use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
+/// use arithmetic_eval::{fns::FnWrapper, Interpreter, Value};
+///
+/// let mut interpreter = Interpreter::new();
+/// let max = FnWrapper::new(|x: f32, y: f32| if x > y { x } else { y });
+/// interpreter.insert_native_fn("max", max);
+///
+/// let program = "max(1, 3) == 3 && max(-1, -3) == -1";
+/// let program = F32Grammar::parse_statements(Span::new(program)).unwrap();
+/// let ret = interpreter.evaluate(&program).unwrap();
+/// assert_eq!(ret, Value::Bool(true));
+/// ```
+///
+/// ## Fallible function with complex args
+///
+/// ```
+/// # use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
+/// # use arithmetic_eval::{fns::FnWrapper, Interpreter, Value};
+/// fn sum_arrays(xs: Vec<f32>, ys: Vec<f32>) -> Result<Vec<f32>, String> {
+///     if xs.len() == ys.len() {
+///         Ok(xs.into_iter().zip(ys).map(|(x, y)| x + y).collect())
+///     } else {
+///         Err("Arrays must have the same size".to_owned())
+///     }
+/// }
+///
+/// let mut interpreter = Interpreter::new();
+/// interpreter.insert_native_fn("sum_arrays", FnWrapper::new(sum_arrays));
+///
+/// let program = "(1, 2, 3).sum_arrays((4, 5, 6)) == (5, 7, 9)";
+/// let program = F32Grammar::parse_statements(Span::new(program)).unwrap();
+/// let ret = interpreter.evaluate(&program).unwrap();
+/// assert_eq!(ret, Value::Bool(true));
+/// ```
+///
+/// ## Usage of context
+///
+/// ```
+/// # use arithmetic_parser::{grammars::F32Grammar, Grammar, GrammarExt, Span};
+/// # use arithmetic_eval::{
+/// #     fns::FnWrapper, CallContext, Function, Interpreter, Value, SpannedEvalError,
+/// # };
+/// fn map_array<'a, G: Grammar<Lit = f32>>(
+///     context: &mut CallContext<'_, 'a>,
+///     array: Vec<Value<'a, G>>,
+///     map_fn: Function<'a, G>,
+/// ) -> Result<Vec<Value<'a, G>>, SpannedEvalError<'a>> {
+///     array
+///         .into_iter()
+///         .map(|value| {
+///             let arg = context.apply_call_span(value);
+///             map_fn.evaluate(vec![arg], context)
+///         })
+///         .collect()
+/// }
+///
+/// let mut interpreter = Interpreter::new();
+/// interpreter.insert_native_fn("map", FnWrapper::new(map_array));
+///
+/// let program = "(1, 2, 3).map(|x| x + 3) == (4, 5, 6)";
+/// let program = F32Grammar::parse_statements(Span::new(program)).unwrap();
+/// let ret = interpreter.evaluate(&program).unwrap();
+/// assert_eq!(ret, Value::Bool(true));
+/// ```
+pub struct FnWrapper<T, F> {
     function: F,
-    _arity: PhantomData<A>,
+    _arg_types: PhantomData<T>,
 }
 
-// Ideally, we would want to constrain `A` and `F`, but this would make it impossible to declare
+impl<T, F> fmt::Debug for FnWrapper<T, F>
+where
+    F: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FnWrapper")
+            .field("function", &self.function)
+            .finish()
+    }
+}
+
+impl<T, F: Clone> Clone for FnWrapper<T, F> {
+    fn clone(&self) -> Self {
+        Self {
+            function: self.function.clone(),
+            _arg_types: PhantomData,
+        }
+    }
+}
+
+impl<T, F: Copy> Copy for FnWrapper<T, F> {}
+
+// Ideally, we would want to constrain `T` and `F`, but this would make it impossible to declare
 // the constructor as `const fn`; see https://github.com/rust-lang/rust/issues/57563.
-impl<A, F> FnWrapper<A, F> {
+impl<T, F> FnWrapper<T, F> {
     /// Creates a new wrapper.
     ///
     /// Note that the created wrapper is not guaranteed to be usable as [`NativeFn`]. For this
     /// to be the case, `function` needs to be a function or an `Fn` closure,
-    /// and the `A` type argument needs to be [`Arity`].
+    /// and the `T` type argument needs to be a tuple with the function return type
+    /// and the argument types (in this order).
+    ///
+    /// [`NativeFn`]: ../trait.NativeFn.html
     pub const fn new(function: F) -> Self {
         Self {
             function,
-            _arity: PhantomData
+            _arg_types: PhantomData,
         }
     }
 }
 
-impl<A: Arity, F> FnWrapper<A, F> {
-    /// Returns the arity of the wrapped function.
-    pub fn arity(&self) -> usize {
-        A::ARITY
+/// Fallible conversion from `Value` to a function argument.
+///
+/// This trait is implemented for base value types (such as [`Number`]s, [`Function`]s, [`Value`]s),
+/// and for two container types: vectors and tuples.
+///
+/// [`Number`]: ../trait.Number.html
+/// [`Function`]: ../enum.Function.html
+/// [`Value`]: ../enum.Value.html
+pub trait TryFromValue<'a, G: Grammar>: Sized {
+    /// Attempts to convert `value` to a type supported by the function.
+    fn try_from_value(value: Value<'a, G>) -> Result<Self, String>;
+}
+
+impl<'a, T: Number, G: Grammar<Lit = T>> TryFromValue<'a, G> for T {
+    fn try_from_value(value: Value<'a, G>) -> Result<Self, String> {
+        match value {
+            Value::Number(number) => Ok(number),
+            _ => Err("Expected number".to_owned()),
+        }
     }
 }
 
-/// Helper trait allowing to extract arity information from a function.
-///
-/// # Examples
-///
-/// Import this trait into the scope and use it to construct functions usable for import
-/// as [`NativeFn`]s:
-///
-/// ```
-///
-/// ```
-pub trait WithArity<T, A: Arity> {
-    /// Wraps the function so that information about its arity is retained.
-    fn with_arity(self) -> FnWrapper<A, Self>
-    where
-        Self: Sized;
+impl<'a, U, G: Grammar> TryFromValue<'a, G> for Vec<U>
+where
+    U: TryFromValue<'a, G>,
+{
+    fn try_from_value(value: Value<'a, G>) -> Result<Self, String> {
+        match value {
+            Value::Tuple(values) => values.into_iter().map(U::try_from_value).collect(),
+            _ => Err("Expected tuple".to_owned()),
+        }
+    }
 }
 
-macro_rules! arity_fn {
-    (@reverse $arg:ident) => { $arg };
-    (@reverse $head:ident $($tail:ident)*) => {
-        arity_fn!($($tail)*), $head
-    };
+impl<'a, G: Grammar> TryFromValue<'a, G> for Value<'a, G> {
+    fn try_from_value(value: Value<'a, G>) -> Result<Self, String> {
+        Ok(value)
+    }
+}
 
-    ($arity:expr, $name:ident => $($arg_name:ident : $t:ident),+) => {
-        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-        pub struct $name;
-
-        impl Arity for $name {
-            const ARITY: usize = $arity;
+impl<'a, G: Grammar> TryFromValue<'a, G> for Function<'a, G> {
+    fn try_from_value(value: Value<'a, G>) -> Result<Self, String> {
+        match value {
+            Value::Function(function) => Ok(function),
+            _ => Err("Expected function".to_owned()),
         }
+    }
+}
 
-        impl<T, F> WithArity<T, $name> for F
+macro_rules! try_from_value_for_tuple {
+    ($size:expr => $($var:ident : $ty:ident),+) => {
+        impl<'a, G: Grammar, $($ty,)+> TryFromValue<'a, G> for ($($ty,)+)
         where
-            F: Fn($($t,)+) -> T
+            $($ty: TryFromValue<'a, G>,)+
         {
-            fn with_arity(self) -> FnWrapper<$name, Self> {
-                FnWrapper {
-                    function: self,
-                    _arity: PhantomData,
+            fn try_from_value(value: Value<'a, G>) -> Result<Self, String> {
+                const MSG: &str = concat!("Expected ", $size, "-element tuple");
+
+                match value {
+                    Value::Tuple(values) if values.len() == $size => {
+                        let mut values_iter = values.into_iter();
+                        $(
+                            let $var = $ty::try_from_value(values_iter.next().unwrap())?;
+                        )+
+                        Ok(($($var,)+))
+                    }
+                    _ => Err(MSG.to_owned()),
                 }
             }
         }
+    };
+}
 
-        impl<T, G, F> NativeFn<G> for FnWrapper<$name, F>
+try_from_value_for_tuple!(1 => x0: T);
+try_from_value_for_tuple!(2 => x0: T, x1: U);
+try_from_value_for_tuple!(3 => x0: T, x1: U, x2: V);
+try_from_value_for_tuple!(4 => x0: T, x1: U, x2: V, x3: W);
+try_from_value_for_tuple!(5 => x0: T, x1: U, x2: V, x3: W, x4: X);
+try_from_value_for_tuple!(6 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y);
+try_from_value_for_tuple!(7 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z);
+try_from_value_for_tuple!(8 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A);
+try_from_value_for_tuple!(9 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B);
+try_from_value_for_tuple!(10 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B, x9: C);
+
+/// Generic error output encompassing all error types supported by [wrapped functions].
+///
+/// [wrapped functions]: struct.FnWrapper.html
+#[derive(Debug)]
+pub enum ErrorOutput<'a> {
+    /// Error together with the defined span(s).
+    Spanned(SpannedEvalError<'a>),
+    /// Error message. The error span will be defined as the call span of the native function.
+    Message(String),
+}
+
+impl<'a> ErrorOutput<'a> {
+    fn into_spanned(self, context: &CallContext<'_, 'a>) -> SpannedEvalError<'a> {
+        match self {
+            Self::Spanned(error) => error,
+            Self::Message(message) => context.call_site_error(EvalError::NativeCall(message)),
+        }
+    }
+}
+
+/// Converts type into `Value` or an error. This is used to convert the return type
+/// of [wrapped functions] to the result expected by [`NativeFn`].
+///
+/// Unlike with `TryInto` trait from the standard library, the erroneous result here does not
+/// mean that the conversion *itself* is impossible. Rather, it means that the function evaluation
+/// has failed for the provided args.
+///
+///
+/// This trait is implemented for base value types (such as [`Number`]s, [`Function`]s, [`Value`]s),
+/// for two container types: vectors and tuples, and for `Result`s with the error type
+/// convertible to [`ErrorOutput`].
+///
+/// [`Number`]: ../trait.Number.html
+/// [`Function`]: ../enum.Function.html
+/// [`Value`]: ../enum.Value.html
+/// [wrapped functions]: struct.FnWrapper.html
+/// [`NativeFn`]: ../trait.NativeFn.html
+/// [`ErrorOutput`]: enum.ErrorOutput.html
+pub trait TryIntoValue<'a, G: Grammar> {
+    /// Performs the conversion.
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>>;
+}
+
+impl<'a, G: Grammar, U> TryIntoValue<'a, G> for Result<U, String>
+where
+    U: TryIntoValue<'a, G>,
+{
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        self.map_err(ErrorOutput::Message)
+            .and_then(U::try_into_value)
+    }
+}
+
+impl<'a, G: Grammar, U> TryIntoValue<'a, G> for Result<U, SpannedEvalError<'a>>
+where
+    U: TryIntoValue<'a, G>,
+{
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        self.map_err(ErrorOutput::Spanned)
+            .and_then(U::try_into_value)
+    }
+}
+
+impl<'a, G: Grammar> TryIntoValue<'a, G> for Value<'a, G> {
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        Ok(self)
+    }
+}
+
+impl<'a, G: Grammar> TryIntoValue<'a, G> for Function<'a, G> {
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        Ok(Value::Function(self))
+    }
+}
+
+impl<'a, T: Number, G: Grammar<Lit = T>> TryIntoValue<'a, G> for T {
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        Ok(Value::Number(self))
+    }
+}
+
+impl<'a, U, G: Grammar> TryIntoValue<'a, G> for Vec<U>
+where
+    U: TryIntoValue<'a, G>,
+{
+    fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        let values = self
+            .into_iter()
+            .map(U::try_into_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Value::Tuple(values))
+    }
+}
+
+macro_rules! into_value_for_tuple {
+    ($($i:tt : $ty:ident),+) => {
+        impl<'a, G: Grammar, $($ty,)+> TryIntoValue<'a, G> for ($($ty,)+)
         where
-            T: Clone + fmt::Debug,
-            G: Grammar<Lit = T>,
-            F: Fn($($t,)+) -> T,
+            $($ty: TryIntoValue<'a, G>,)+
         {
-            fn evaluate<'a>(
+            fn try_into_value(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+                Ok(Value::Tuple(vec![$(self.$i.try_into_value()?,)+]))
+            }
+        }
+    };
+}
+
+into_value_for_tuple!(0: T);
+into_value_for_tuple!(0: T, 1: U);
+into_value_for_tuple!(0: T, 1: U, 2: V);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X, 5: Y);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X, 5: Y, 6: Z);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X, 5: Y, 6: Z, 7: A);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X, 5: Y, 6: Z, 7: A, 8: B);
+into_value_for_tuple!(0: T, 1: U, 2: V, 3: W, 4: X, 5: Y, 6: Z, 7: A, 8: B, 9: C);
+
+/// Marker for use with [wrapper functions] accepting context as the first argument.
+///
+/// [wrapper functions]: struct.FnWrapper.html
+#[derive(Debug)]
+pub struct WithContext<T>(T);
+
+macro_rules! arity_fn {
+    ($arity:tt => $($arg_name:ident : $t:ident),+) => {
+        impl<'a, G, F, Ret, $($t,)+> NativeFn<'a, G> for FnWrapper<(Ret, $($t,)+), F>
+        where
+            G: Grammar,
+            F: Fn($($t,)+) -> Ret,
+            $($t: TryFromValue<'a, G>,)+
+            Ret: TryIntoValue<'a, G>,
+        {
+            fn evaluate(
                 &self,
                 args: Vec<SpannedValue<'a, G>>,
                 context: &mut CallContext<'_, 'a>,
             ) -> EvalResult<'a, G> {
-                const MSG: &str = concat!("Function requires ", $arity, " primitive argument(s)");
-
                 context.check_args_count(&args, $arity)?;
                 let mut args_iter = args.into_iter();
 
                 $(
                     let $arg_name = args_iter.next().unwrap();
-                    let $arg_name = extract_number(context, $arg_name, MSG)?;
+                    let span = create_span_ref(&$arg_name, ());
+                    let $arg_name = $t::try_from_value($arg_name.extra)
+                        .map_err(|error_msg| {
+                            context
+                                .call_site_error(EvalError::native(error_msg))
+                                .with_span(&span, AuxErrorInfo::InvalidArg)
+                        })?;
                 )+
 
                 let output = (self.function)($($arg_name,)+);
-                Ok(Value::Number(output))
+                output.try_into_value().map_err(|err| err.into_spanned(context))
+            }
+        }
+
+        impl<'a, G, F, Ret, $($t,)+> NativeFn<'a, G> for FnWrapper<WithContext<(Ret, $($t,)+)>, F>
+        where
+            G: Grammar,
+            F: Fn(&mut CallContext<'_, 'a>, $($t,)+) -> Ret,
+            $($t: TryFromValue<'a, G>,)+
+            Ret: TryIntoValue<'a, G>,
+        {
+            fn evaluate(
+                &self,
+                args: Vec<SpannedValue<'a, G>>,
+                context: &mut CallContext<'_, 'a>,
+            ) -> EvalResult<'a, G> {
+                context.check_args_count(&args, $arity)?;
+                let mut args_iter = args.into_iter();
+
+                $(
+                    let $arg_name = args_iter.next().unwrap();
+                    let span = create_span_ref(&$arg_name, ());
+                    let $arg_name = $t::try_from_value($arg_name.extra)
+                        .map_err(|error_msg| {
+                            context
+                                .call_site_error(EvalError::native(error_msg))
+                                .with_span(&span, AuxErrorInfo::InvalidArg)
+                        })?;
+                )+
+
+                let output = (self.function)(context, $($arg_name,)+);
+                output.try_into_value().map_err(|err| err.into_spanned(context))
             }
         }
     };
 }
 
-arity_fn!(1, Arity1 => x: T);
-arity_fn!(2, Arity2 => x: T, y: T);
-arity_fn!(3, Arity3 => x: T, y: T, z: T);
-arity_fn!(4, Arity4 => x0: T, x1: T, x2: T, x3: T);
-arity_fn!(5, Arity5 => x0: T, x1: T, x2: T, x3: T, x4: T);
-arity_fn!(6, Arity6 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T);
-arity_fn!(7, Arity7 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T);
-arity_fn!(8, Arity8 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T);
-arity_fn!(9, Arity9 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T, x8: T);
-arity_fn!(10, Arity10 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T, x8: T, x9: T);
+arity_fn!(1 => x0: T);
+arity_fn!(2 => x0: T, x1: U);
+arity_fn!(3 => x0: T, x1: U, x2: V);
+arity_fn!(4 => x0: T, x1: U, x2: V, x3: W);
+arity_fn!(5 => x0: T, x1: U, x2: V, x3: W, x4: X);
+arity_fn!(6 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y);
+arity_fn!(7 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z);
+arity_fn!(8 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A);
+arity_fn!(9 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B);
+arity_fn!(10 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B, x9: C);
 
 /// Unary function wrapper.
-pub type Unary<F> = FnWrapper<Arity1, F>;
+pub type Unary<T> = FnWrapper<(T, T), fn(T) -> T>;
 
 /// Binary function wrapper.
-pub type Binary<F> = FnWrapper<Arity2, F>;
+pub type Binary<T> = FnWrapper<(T, T, T), fn(T, T) -> T>;
 
 /// Ternary function wrapper.
-pub type Ternary<F> = FnWrapper<Arity3, F>;
+pub type Ternary<T> = FnWrapper<(T, T, T, T), fn(T, T, T) -> T>;
 
 /// Quaternary function wrapper.
-pub type Quaternary<F> = FnWrapper<Arity4, F>;
-
-/// Quinary function wrapper.
-pub type Quinary<F> = FnWrapper<Arity5, F>;
-
-/// Senary function wrapper.
-pub type Senary<F> = FnWrapper<Arity6, F>;
-
-/// Septenary function wrapper.
-pub type Septenary<F> = FnWrapper<Arity7, F>;
-
-/// Octonary function wrapper.
-pub type Octonary<F> = FnWrapper<Arity8, F>;
-
-/// Novenary function wrapper.
-pub type Novenary<F> = FnWrapper<Arity9, F>;
-
-/// Denary function wrapper.
-pub type Denary<F> = FnWrapper<Arity10, F>;
+pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 
 #[cfg(test)]
 mod tests {
@@ -169,11 +451,13 @@ mod tests {
     use crate::Interpreter;
     use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
 
+    use core::f32;
+
     #[test]
-    fn functions_work() {
-        let unary_fn = (|x: f32| x + 3.0).with_arity();
-        let binary_fn = f32::min.with_arity();
-        let ternary_fn = (|x: f32, y: f32, z: f32| if x > 0.0 { y } else { z }).with_arity();
+    fn functions_with_primitive_args() {
+        let unary_fn = Unary::new(|x: f32| x + 3.0);
+        let binary_fn = Binary::new(f32::min);
+        let ternary_fn = Ternary::new(|x: f32, y, z| if x > 0.0 { y } else { z });
 
         let mut interpreter = Interpreter::new();
         interpreter
@@ -188,5 +472,67 @@ mod tests {
         let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
         let ret = interpreter.evaluate(&block).unwrap();
         assert_eq!(ret, Value::Bool(true));
+    }
+
+    fn array_min_max(values: Vec<f32>) -> (f32, f32) {
+        let mut min = f32::INFINITY;
+        let mut max = f32::NEG_INFINITY;
+
+        for value in values {
+            if value < min {
+                min = value;
+            }
+            if value > max {
+                max = value;
+            }
+        }
+        (min, max)
+    }
+
+    fn overly_convoluted_fn(xs: Vec<(f32, f32)>, ys: (Vec<f32>, f32)) -> f32 {
+        xs.into_iter().map(|(a, b)| a + b).sum::<f32>() + ys.0.into_iter().sum::<f32>() + ys.1
+    }
+
+    #[test]
+    fn functions_with_composite_args() {
+        let mut interpreter = Interpreter::new();
+        interpreter
+            .insert_native_fn("array_min_max", FnWrapper::new(array_min_max))
+            .insert_native_fn("total_sum", FnWrapper::new(overly_convoluted_fn));
+
+        let program = r#"
+            (1, 5, -3, 2, 1).array_min_max() == (-3, 5) &&
+                total_sum(((1, 2), (3, 4)), ((5, 6, 7), 8)) == 36
+        "#;
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let ret = interpreter.evaluate(&block).unwrap();
+        assert_eq!(ret, Value::Bool(true));
+    }
+
+    fn sum_arrays(xs: Vec<f32>, ys: Vec<f32>) -> Result<Vec<f32>, String> {
+        if xs.len() == ys.len() {
+            Ok(xs.into_iter().zip(ys).map(|(x, y)| x + y).collect())
+        } else {
+            Err("Summed arrays must have the same size".to_owned())
+        }
+    }
+
+    #[test]
+    fn fallible_function() {
+        let mut interpreter = Interpreter::new();
+        interpreter.insert_native_fn("sum_arrays", FnWrapper::new(sum_arrays));
+
+        let program = "(1, 2, 3).sum_arrays((4, 5, 6)) == (5, 7, 9)";
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let ret = interpreter.evaluate(&block).unwrap();
+        assert_eq!(ret, Value::Bool(true));
+
+        let program = "(1, 2, 3).sum_arrays((4, 5))";
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let err = interpreter.evaluate(&block).unwrap_err();
+        assert!(err
+            .source()
+            .to_short_string()
+            .contains("Summed arrays must have the same size"));
     }
 }

--- a/eval/src/fns/arity.rs
+++ b/eval/src/fns/arity.rs
@@ -1,0 +1,192 @@
+use arithmetic_parser::Grammar;
+
+use core::{fmt, marker::PhantomData};
+
+use crate::{fns::extract_number, CallContext, EvalResult, NativeFn, SpannedValue, Value};
+
+/// Arity of a function expressed as a trait.
+///
+/// # Implementation details
+///
+/// The necessity of this trait stems from the fact that stable Rust does not so far
+/// support [const generics].
+///
+/// [const generics]: https://github.com/rust-lang/rust/issues/44580
+pub trait Arity {
+    /// Function arity.
+    const ARITY: usize;
+}
+
+/// Wrapper of a function containing information about its arity.
+///
+/// The instances of this type are created by applying [`WithArity`] trait to a function or closure.
+///
+/// [`WithArity`]: trait.WithArity.html
+#[derive(Debug, Clone, Copy)]
+pub struct FnWrapper<A, F> {
+    function: F,
+    _arity: PhantomData<A>,
+}
+
+// Ideally, we would want to constrain `A` and `F`, but this would make it impossible to declare
+// the constructor as `const fn`; see https://github.com/rust-lang/rust/issues/57563.
+impl<A, F> FnWrapper<A, F> {
+    /// Creates a new wrapper.
+    ///
+    /// Note that the created wrapper is not guaranteed to be usable as [`NativeFn`]. For this
+    /// to be the case, `function` needs to be a function or an `Fn` closure,
+    /// and the `A` type argument needs to be [`Arity`].
+    pub const fn new(function: F) -> Self {
+        Self {
+            function,
+            _arity: PhantomData
+        }
+    }
+}
+
+impl<A: Arity, F> FnWrapper<A, F> {
+    /// Returns the arity of the wrapped function.
+    pub fn arity(&self) -> usize {
+        A::ARITY
+    }
+}
+
+/// Helper trait allowing to extract arity information from a function.
+///
+/// # Examples
+///
+/// Import this trait into the scope and use it to construct functions usable for import
+/// as [`NativeFn`]s:
+///
+/// ```
+///
+/// ```
+pub trait WithArity<T, A: Arity> {
+    /// Wraps the function so that information about its arity is retained.
+    fn with_arity(self) -> FnWrapper<A, Self>
+    where
+        Self: Sized;
+}
+
+macro_rules! arity_fn {
+    (@reverse $arg:ident) => { $arg };
+    (@reverse $head:ident $($tail:ident)*) => {
+        arity_fn!($($tail)*), $head
+    };
+
+    ($arity:expr, $name:ident => $($arg_name:ident : $t:ident),+) => {
+        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+        pub struct $name;
+
+        impl Arity for $name {
+            const ARITY: usize = $arity;
+        }
+
+        impl<T, F> WithArity<T, $name> for F
+        where
+            F: Fn($($t,)+) -> T
+        {
+            fn with_arity(self) -> FnWrapper<$name, Self> {
+                FnWrapper {
+                    function: self,
+                    _arity: PhantomData,
+                }
+            }
+        }
+
+        impl<T, G, F> NativeFn<G> for FnWrapper<$name, F>
+        where
+            T: Clone + fmt::Debug,
+            G: Grammar<Lit = T>,
+            F: Fn($($t,)+) -> T,
+        {
+            fn evaluate<'a>(
+                &self,
+                args: Vec<SpannedValue<'a, G>>,
+                context: &mut CallContext<'_, 'a>,
+            ) -> EvalResult<'a, G> {
+                const MSG: &str = concat!("Function requires ", $arity, " primitive argument(s)");
+
+                context.check_args_count(&args, $arity)?;
+                let mut args_iter = args.into_iter();
+
+                $(
+                    let $arg_name = args_iter.next().unwrap();
+                    let $arg_name = extract_number(context, $arg_name, MSG)?;
+                )+
+
+                let output = (self.function)($($arg_name,)+);
+                Ok(Value::Number(output))
+            }
+        }
+    };
+}
+
+arity_fn!(1, Arity1 => x: T);
+arity_fn!(2, Arity2 => x: T, y: T);
+arity_fn!(3, Arity3 => x: T, y: T, z: T);
+arity_fn!(4, Arity4 => x0: T, x1: T, x2: T, x3: T);
+arity_fn!(5, Arity5 => x0: T, x1: T, x2: T, x3: T, x4: T);
+arity_fn!(6, Arity6 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T);
+arity_fn!(7, Arity7 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T);
+arity_fn!(8, Arity8 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T);
+arity_fn!(9, Arity9 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T, x8: T);
+arity_fn!(10, Arity10 => x0: T, x1: T, x2: T, x3: T, x4: T, x5: T, x6: T, x7: T, x8: T, x9: T);
+
+/// Unary function wrapper.
+pub type Unary<F> = FnWrapper<Arity1, F>;
+
+/// Binary function wrapper.
+pub type Binary<F> = FnWrapper<Arity2, F>;
+
+/// Ternary function wrapper.
+pub type Ternary<F> = FnWrapper<Arity3, F>;
+
+/// Quaternary function wrapper.
+pub type Quaternary<F> = FnWrapper<Arity4, F>;
+
+/// Quinary function wrapper.
+pub type Quinary<F> = FnWrapper<Arity5, F>;
+
+/// Senary function wrapper.
+pub type Senary<F> = FnWrapper<Arity6, F>;
+
+/// Septenary function wrapper.
+pub type Septenary<F> = FnWrapper<Arity7, F>;
+
+/// Octonary function wrapper.
+pub type Octonary<F> = FnWrapper<Arity8, F>;
+
+/// Novenary function wrapper.
+pub type Novenary<F> = FnWrapper<Arity9, F>;
+
+/// Denary function wrapper.
+pub type Denary<F> = FnWrapper<Arity10, F>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Interpreter;
+    use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
+
+    #[test]
+    fn functions_work() {
+        let unary_fn = (|x: f32| x + 3.0).with_arity();
+        let binary_fn = f32::min.with_arity();
+        let ternary_fn = (|x: f32, y: f32, z: f32| if x > 0.0 { y } else { z }).with_arity();
+
+        let mut interpreter = Interpreter::new();
+        interpreter
+            .insert_native_fn("unary_fn", unary_fn)
+            .insert_native_fn("binary_fn", binary_fn)
+            .insert_native_fn("ternary_fn", ternary_fn);
+
+        let program = r#"
+            unary_fn(2) == 5 && binary_fn(1, -3) == -3 &&
+                ternary_fn(1, 2, 3) == 2 && ternary_fn(-1, 2, 3) == 3
+        "#;
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let ret = interpreter.evaluate(&block).unwrap();
+        assert_eq!(ret, Value::Bool(true));
+    }
+}

--- a/eval/src/fns/wrapper.rs
+++ b/eval/src/fns/wrapper.rs
@@ -55,18 +55,18 @@ pub const fn wrap<T, F>(function: F) -> FnWrapper<T, F> {
 /// ```
 /// # use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
 /// # use arithmetic_eval::{fns::FnWrapper, Interpreter, Value};
-/// fn sum_arrays(xs: Vec<f32>, ys: Vec<f32>) -> Result<Vec<f32>, String> {
+/// fn zip_arrays(xs: Vec<f32>, ys: Vec<f32>) -> Result<Vec<(f32, f32)>, String> {
 ///     if xs.len() == ys.len() {
-///         Ok(xs.into_iter().zip(ys).map(|(x, y)| x + y).collect())
+///         Ok(xs.into_iter().zip(ys).map(|(x, y)| (x, y)).collect())
 ///     } else {
 ///         Err("Arrays must have the same size".to_owned())
 ///     }
 /// }
 ///
 /// let mut interpreter = Interpreter::new();
-/// interpreter.insert_native_fn("sum_arrays", FnWrapper::new(sum_arrays));
+/// interpreter.insert_native_fn("zip", FnWrapper::new(zip_arrays));
 ///
-/// let program = "(1, 2, 3).sum_arrays((4, 5, 6)) == (5, 7, 9)";
+/// let program = "(1, 2, 3).zip((4, 5, 6)) == ((1, 4), (2, 5), (3, 6))";
 /// let program = F32Grammar::parse_statements(Span::new(program)).unwrap();
 /// let ret = interpreter.evaluate(&program).unwrap();
 /// assert_eq!(ret, Value::Bool(true));

--- a/eval/src/values.rs
+++ b/eval/src/values.rs
@@ -217,6 +217,41 @@ where
     }
 }
 
+/// Possible high-level types of [`Value`]s.
+///
+/// [`Value`]: enum.Value.html
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ValueType {
+    /// Number.
+    Number,
+    /// Boolean value.
+    Bool,
+    /// Function value.
+    Function,
+    /// Tuple of a specific size.
+    Tuple(usize),
+    /// Array (a tuple of arbitrary size).
+    ///
+    /// This variant is never returned from [`Value::value_type()`]; at the same time, it is
+    /// used for error reporting etc.
+    ///
+    /// [`Value::value_type()`]: enum.Value.html#method.value_type
+    Array,
+}
+
+impl fmt::Display for ValueType {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Number => formatter.write_str("number"),
+            Self::Bool => formatter.write_str("boolean value"),
+            Self::Function => formatter.write_str("function"),
+            Self::Tuple(1) => write!(formatter, "tuple with 1 element"),
+            Self::Tuple(size) => write!(formatter, "tuple with {} elements", size),
+            Self::Array => formatter.write_str("array"),
+        }
+    }
+}
+
 /// Values produced by expressions during their interpretation.
 #[derive(Debug)]
 pub enum Value<'a, T>
@@ -250,6 +285,16 @@ impl<'a, T: Grammar> Value<'a, T> {
     /// Creates a void value (an empty tuple).
     pub fn void() -> Self {
         Self::Tuple(vec![])
+    }
+
+    /// Returns the type of this value.
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Self::Number(_) => ValueType::Number,
+            Self::Bool(_) => ValueType::Bool,
+            Self::Function(_) => ValueType::Function,
+            Self::Tuple(elements) => ValueType::Tuple(elements.len()),
+        }
     }
 
     /// Checks if the value is void.

--- a/eval/tests/hof.rs
+++ b/eval/tests/hof.rs
@@ -1,0 +1,68 @@
+//! Demonstrates how to define high-order native functions.
+
+use arithmetic_eval::{
+    fns, CallContext, EvalError, EvalResult, Function, Interpreter, NativeFn, Number, SpannedValue,
+    Value,
+};
+use arithmetic_parser::{grammars::F32Grammar, Grammar, GrammarExt, Span};
+
+/// Function that applies the `inner` function the specified amount of times to the result of
+/// the previous execution.
+#[derive(Debug, Clone)]
+struct Repeated<'a, G: Grammar> {
+    inner: Function<'a, G>,
+    times: usize,
+}
+
+impl<'a, G: Grammar> NativeFn<'a, G> for Repeated<'a, G>
+where
+    G::Lit: Number,
+{
+    fn evaluate(
+        &self,
+        mut args: Vec<SpannedValue<'a, G>>,
+        context: &mut CallContext<'_, 'a>,
+    ) -> EvalResult<'a, G> {
+        if args.len() != 1 {
+            let err = EvalError::native("Should be called with single argument");
+            return Err(context.call_site_error(err));
+        }
+        let mut arg = args.pop().unwrap();
+        for _ in 0..self.times {
+            let result = self.inner.evaluate(vec![arg], context)?;
+            arg = context.apply_call_span(result);
+        }
+        Ok(arg.extra)
+    }
+}
+
+fn repeat<G: Grammar<Lit = f32>>(
+    function: Function<'_, G>,
+    times: f32,
+) -> Result<Function<'_, G>, String> {
+    if times < 0.0 {
+        Err("`times` should be positive".to_owned())
+    } else {
+        let function = Repeated {
+            inner: function,
+            times: times as usize,
+        };
+        Ok(Function::native(function))
+    }
+}
+
+#[test]
+fn repeated_function() {
+    let mut interpreter = Interpreter::new();
+    interpreter.insert_native_fn("repeat", fns::wrap(repeat));
+
+    let program = r#"
+        fn = |x| 2*x + 1;
+        repeated = fn.repeat(3);
+        repeated(1) == 15 &&    # 2 * 1 + 1 = 3 -> 2 * 3 + 1 = 7 -> 2 * 7 + 1 = 15
+            repeated(-1) == -1  # -1 is the immovable point of the transform
+    "#;
+    let program = F32Grammar::parse_statements(Span::new(program)).unwrap();
+    let ret = interpreter.evaluate(&program).unwrap();
+    assert_eq!(ret, Value::Bool(true));
+}

--- a/parser/src/grammars.rs
+++ b/parser/src/grammars.rs
@@ -6,9 +6,9 @@ use nom::{
     number::complete::{double, float},
     sequence::terminated,
 };
-use num_traits::{Num, Pow};
+use num_traits::Num;
 
-use core::{f32, f64, fmt, marker::PhantomData, ops};
+use core::{f32, f64, fmt, marker::PhantomData};
 
 use crate::{Features, Grammar, NomResult, Span};
 
@@ -42,9 +42,7 @@ impl<T: NumLiteral> Grammar for NumGrammar<T> {
 }
 
 /// Numeric literal used in `NumGrammar`s.
-pub trait NumLiteral:
-    'static + Copy + Num + fmt::Debug + ops::Neg<Output = Self> + Pow<Self, Output = Self>
-{
+pub trait NumLiteral: 'static + Copy + Num + fmt::Debug {
     /// Tries to parse a literal.
     fn parse(input: Span<'_>) -> NomResult<'_, Self>;
 }


### PR DESCRIPTION
...to make their usage easier for a wider range of use cases.

Now, it is possible to define native functions with primitive / tuple / vector arguments and primitive / tuple / vector / result return types.

TODO list:

- [x] Sane error reporting for argument conversion failures and the corresponding tests.

Closes #3, #11.