### PR TITLE
Add import getters for `ExecutableModule`

### DIFF
--- a/eval/src/compiler.rs
+++ b/eval/src/compiler.rs
@@ -685,7 +685,7 @@ mod tests {
         let module = F32Grammar::parse_statements(Span::new(module)).unwrap();
         let mut module = Compiler::compile_module(&env, &module, false).unwrap();
 
-        let imports = module.imports().collect::<Vec<_>>();
+        let imports = module.imports().iter().collect::<Vec<_>>();
         assert_eq!(imports, &[("x", &Value::Number(1.0))]);
         let value = module.run().unwrap();
         assert_eq!(value, Value::Number(2.0));

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -451,6 +451,7 @@ where
 /// assert_eq!(module.run().unwrap(), Value::Number(f32::NEG_INFINITY));
 ///
 /// // Imports can be changed. Let's check that `xs` is indeed an import.
+/// assert!(module.has_import("xs"));
 /// let imports: HashSet<_> = module.imports().map(|(name, _)| name).collect();
 /// assert!(imports.is_superset(&HashSet::from_iter(vec!["max", "fold", "xs"])));
 ///
@@ -470,11 +471,24 @@ impl<'a, T: Grammar> ExecutableModule<'a, T> {
         Self { inner, imports }
     }
 
+    /// Checks if a variable with the specified name is imported to this module.
+    pub fn has_import(&self, name: &str) -> bool {
+        self.imports.vars.contains_key(name)
+    }
+
+    /// Gets the current value of the import with the specified name, or `None` if the import
+    /// is not defined.
+    pub fn import(&self, name: &str) -> Option<&Value<'a, T>> {
+        self.imports.get_var(name)
+    }
+
     /// Sets the value of an imported variable.
     ///
     /// # Panics
     ///
-    /// Panics if the variable with the specified name is not an import.
+    /// Panics if the variable with the specified name is not an import. Check
+    /// that the import exists beforehand via [`has_import()`](#method.has_import) if this is
+    /// unknown at compile time.
     pub fn set_import(&mut self, name: &str, value: Value<'a, T>) -> &mut Self {
         self.imports.set_var(name, value);
         self

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -99,7 +99,7 @@ pub use self::{
         AuxErrorInfo, Backtrace, BacktraceElement, ErrorWithBacktrace, EvalError, EvalResult,
         RepeatedAssignmentContext, SpannedEvalError, TupleLenMismatchContext,
     },
-    executable::ExecutableModule,
+    executable::{ExecutableModule, ModuleImports},
     values::{CallContext, Function, InterpretedFn, NativeFn, SpannedValue, Value, ValueType},
 };
 


### PR DESCRIPTION
...allowing to quickly check if a certain import exists for the module. Also, module imports are extracted into a separate entity.

closes #7, closes #10  
related to #13 (but does not solve it completely)