### PR TITLE
Interpreter improvements

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -330,18 +330,7 @@ impl<'a> Env<'a> {
 }
 
 fn init_interpreter<'a, T: Number>() -> Interpreter<'a, NumGrammar<T>> {
-    let mut interpreter = Interpreter::<NumGrammar<T>>::new();
-    interpreter
-        .insert_var("false", Value::Bool(false))
-        .insert_var("true", Value::Bool(true))
-        .insert_native_fn("if", fns::If)
-        .insert_native_fn("loop", fns::Loop)
-        .insert_native_fn("map", fns::Map)
-        .insert_native_fn("filter", fns::Filter)
-        .insert_native_fn("fold", fns::Fold)
-        .insert_native_fn("push", fns::Push)
-        .insert_native_fn("merge", fns::Merge);
-    interpreter
+    Interpreter::<NumGrammar<T>>::with_prelude()
 }
 
 pub trait ReplLiteral: Number + fmt::Display {

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -1,14 +1,11 @@
 //! Executables output by a `Compiler` and related types.
 
 use hashbrown::HashMap;
-use num_traits::{Num, Pow};
 use smallvec::{smallvec, SmallVec};
-
-use core::ops;
 
 use crate::{
     alloc::{vec, Rc, Vec},
-    Backtrace, CallContext, ErrorWithBacktrace, EvalError, EvalResult, InterpretedFn,
+    Backtrace, CallContext, ErrorWithBacktrace, EvalError, EvalResult, InterpretedFn, Number,
     SpannedEvalError, TupleLenMismatchContext, Value,
 };
 use arithmetic_parser::{create_span_ref, BinaryOp, Grammar, LvalueLen, Span, Spanned, UnaryOp};
@@ -140,7 +137,7 @@ impl<'a, T: Grammar> Executable<'a, T> {
 impl<'a, T> Executable<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     pub(super) fn call_function(
         &self,
@@ -238,7 +235,7 @@ impl<'a, T: Grammar> Env<'a, T> {
 impl<'a, T> Env<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     pub fn execute(
         &mut self,
@@ -418,7 +415,7 @@ where
     fn resolve_atom(&self, atom: &Atom<T>) -> Value<'a, T> {
         match atom {
             Atom::Register(index) => self.registers[*index].clone(),
-            Atom::Constant(value) => Value::Number(value.clone()),
+            Atom::Constant(value) => Value::Number(*value),
             Atom::Void => Value::void(),
         }
     }
@@ -492,7 +489,7 @@ impl<'a, T: Grammar> ExecutableModule<'a, T> {
 
 impl<'a, T: Grammar> ExecutableModule<'a, T>
 where
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     /// Runs the module with the current values of imports.
     pub fn run(&self) -> Result<Value<'a, T>, ErrorWithBacktrace<'a>> {

--- a/eval/src/fns/wrapper.rs
+++ b/eval/src/fns/wrapper.rs
@@ -661,8 +661,8 @@ mod tests {
     fn functions_with_composite_args() {
         let mut interpreter = Interpreter::new();
         interpreter
-            .insert_native_fn("array_min_max", FnWrapper::new(array_min_max))
-            .insert_native_fn("total_sum", FnWrapper::new(overly_convoluted_fn));
+            .insert_wrapped_fn("array_min_max", array_min_max)
+            .insert_wrapped_fn("total_sum", overly_convoluted_fn);
 
         let program = r#"
             (1, 5, -3, 2, 1).array_min_max() == (-3, 5) &&
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn fallible_function() {
         let mut interpreter = Interpreter::new();
-        interpreter.insert_native_fn("sum_arrays", FnWrapper::new(sum_arrays));
+        interpreter.insert_wrapped_fn("sum_arrays", sum_arrays);
 
         let program = "(1, 2, 3).sum_arrays((4, 5, 6)) == (5, 7, 9)";
         let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
@@ -717,19 +717,16 @@ mod tests {
     #[test]
     fn function_with_void_return_value() {
         let mut interpreter = Interpreter::new();
-        interpreter.insert_native_fn(
-            "assert_eq",
-            wrap(|expected: f32, actual: f32| {
-                if (expected - actual).abs() < f32::EPSILON {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "Assertion failed: expected {}, got {}",
-                        expected, actual
-                    ))
-                }
-            }),
-        );
+        interpreter.insert_wrapped_fn("assert_eq", |expected: f32, actual: f32| {
+            if (expected - actual).abs() < f32::EPSILON {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Assertion failed: expected {}, got {}",
+                    expected, actual
+                ))
+            }
+        });
 
         let program = "assert_eq(3, 1 + 2)";
         let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
@@ -751,9 +748,9 @@ mod tests {
         interpreter
             .insert_var("true", Value::Bool(true))
             .insert_var("false", Value::Bool(false));
-        interpreter.insert_native_fn(
+        interpreter.insert_wrapped_fn(
             "flip_sign",
-            wrap(|val: f32, flag: bool| if flag { -val } else { val }),
+            |val: f32, flag: bool| if flag { -val } else { val },
         );
 
         let program = "flip_sign(-1, true) == 1 && flip_sign(-1, false) == -1";
@@ -768,15 +765,12 @@ mod tests {
         interpreter
             .insert_var("true", Value::Bool(true))
             .insert_var("false", Value::Bool(false));
-        interpreter.insert_native_fn(
-            "destructure",
-            wrap(|values: Vec<(bool, f32)>| {
-                values
-                    .into_iter()
-                    .map(|(flag, x)| if flag { x } else { 0.0 })
-                    .sum::<f32>()
-            }),
-        );
+        interpreter.insert_wrapped_fn("destructure", |values: Vec<(bool, f32)>| {
+            values
+                .into_iter()
+                .map(|(flag, x)| if flag { x } else { 0.0 })
+                .sum::<f32>()
+        });
 
         let program = "((true, 1), (2, 3)).destructure()";
         let block = F32Grammar::parse_statements(Span::new(program)).unwrap();

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -157,17 +157,17 @@ where
     }
 
     /// Gets a variable by name.
-    pub fn get_var(&self, name: &'a str) -> Option<&Value<'a, T>> {
+    pub fn get_var(&self, name: &str) -> Option<&Value<'a, T>> {
         self.env.get_var(name)
     }
 
     /// Iterates over variables.
-    pub fn variables(&self) -> impl Iterator<Item = (&'a str, &Value<'a, T>)> + '_ {
+    pub fn variables(&self) -> impl Iterator<Item = (&str, &Value<'a, T>)> + '_ {
         self.env.variables()
     }
 
     /// Inserts a variable with the specified name.
-    pub fn insert_var(&mut self, name: &'a str, value: Value<'a, T>) -> &mut Self {
+    pub fn insert_var(&mut self, name: &str, value: Value<'a, T>) -> &mut Self {
         self.env.push_var(name, value);
         self
     }
@@ -175,7 +175,7 @@ where
     /// Inserts a native function with the specified name.
     pub fn insert_native_fn(
         &mut self,
-        name: &'a str,
+        name: &str,
         native_fn: impl NativeFn<'a, T> + 'a,
     ) -> &mut Self {
         self.insert_var(name, Value::native_fn(native_fn))
@@ -191,7 +191,7 @@ where
     ///
     /// [wrapped function]: fns/struct.FnWrapper.html
     /// [`wrap`]: fns/fn.wrap.html
-    pub fn insert_wrapped_fn<Args: 'a, F: 'a>(&mut self, name: &'a str, fn_to_wrap: F) -> &mut Self
+    pub fn insert_wrapped_fn<Args: 'a, F: 'a>(&mut self, name: &str, fn_to_wrap: F) -> &mut Self
     where
         fns::FnWrapper<Args, F>: NativeFn<'a, T>,
     {

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -44,12 +44,11 @@
 //! const MAX: fns::Binary<f32> =
 //!     fns::Binary::new(|x, y| if x > y { x } else { y });
 //!
-//! let mut context = Interpreter::new();
+//! let mut context = Interpreter::with_prelude();
 //! // Add some native functions to the interpreter.
 //! context
 //!     .insert_native_fn("min", MIN)
-//!     .insert_native_fn("max", MAX)
-//!     .insert_native_fn("assert", fns::Assert);
+//!     .insert_native_fn("max", MAX);
 //!
 //! let program = r#"
 //!     ## The interpreter supports all parser features, including
@@ -188,6 +187,34 @@ where
     T: Grammar,
     T::Lit: Number,
 {
+    /// Returns an interpreter with most of functions from the [`fns` module] imported in.
+    ///
+    /// # Return value
+    ///
+    /// The returned interpreter contains the following variables:
+    ///
+    /// - All functions from the `fns` module, except for [`Compare`] (since it requires
+    ///   `PartialOrd` implementation for numbers). All functions are named in lowercase,
+    ///   e.g., `if`, `map`.
+    /// - `true` and `false` Boolean constants.
+    ///
+    /// [`fns` module]: fns/index.html
+    /// [`Compare`]: fns/struct.Compare.html
+    pub fn with_prelude() -> Self {
+        let mut this = Self::new();
+        this.insert_var("false", Value::Bool(false))
+            .insert_var("true", Value::Bool(true))
+            .insert_native_fn("assert", fns::Assert)
+            .insert_native_fn("if", fns::If)
+            .insert_native_fn("loop", fns::Loop)
+            .insert_native_fn("map", fns::Map)
+            .insert_native_fn("filter", fns::Filter)
+            .insert_native_fn("fold", fns::Fold)
+            .insert_native_fn("push", fns::Push)
+            .insert_native_fn("merge", fns::Merge);
+        this
+    }
+
     /// Evaluates a list of statements.
     pub fn evaluate(
         &mut self,

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -180,6 +180,24 @@ where
     ) -> &mut Self {
         self.insert_var(name, Value::native_fn(native_fn))
     }
+
+    /// Inserts a [wrapped function] with the specified name.
+    ///
+    /// Calling this method is equivalent to [`wrap`]ping a function and calling
+    /// [`insert_native_fn()`](#method.insert_native_fn) on it. Thanks to type inference magic,
+    /// the Rust compiler will usually be able to extract the `Args` type param
+    /// from the function definition, provided that type of function arguments and its return type
+    /// are defined explicitly or can be unequivocally inferred from the declaration.
+    ///
+    /// [wrapped function]: fns/struct.FnWrapper.html
+    /// [`wrap`]: fns/fn.wrap.html
+    pub fn insert_wrapped_fn<Args: 'a, F: 'a>(&mut self, name: &'a str, fn_to_wrap: F) -> &mut Self
+    where
+        fns::FnWrapper<Args, F>: NativeFn<'a, T>,
+    {
+        let wrapped = fns::wrap::<Args, _>(fn_to_wrap);
+        self.insert_var(name, Value::native_fn(wrapped))
+    }
 }
 
 impl<'a, T> Interpreter<'a, T>

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -104,7 +104,7 @@ pub use self::{
 };
 
 use num_complex::{Complex32, Complex64};
-use num_traits::{Num, Pow};
+use num_traits::Pow;
 
 use core::ops;
 
@@ -133,7 +133,7 @@ pub struct Interpreter<'a, T: Grammar> {
 
 impl<T: Grammar> Default for Interpreter<'_, T>
 where
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn default() -> Self {
         Self::new()
@@ -186,7 +186,7 @@ where
 impl<'a, T> Interpreter<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     /// Evaluates a list of statements.
     pub fn evaluate(

--- a/eval/src/values.rs
+++ b/eval/src/values.rs
@@ -1,14 +1,15 @@
 //! Values used by the interpreter.
 
 use hashbrown::HashMap;
-use num_traits::{Num, Pow};
+use num_traits::Pow;
 
-use core::{fmt, ops};
+use core::fmt;
 
 use crate::{
     alloc::{vec, Rc, Vec},
     executable::ExecutableFn,
-    AuxErrorInfo, Backtrace, EvalError, EvalResult, SpannedEvalError, TupleLenMismatchContext,
+    AuxErrorInfo, Backtrace, EvalError, EvalResult, Number, SpannedEvalError,
+    TupleLenMismatchContext,
 };
 use arithmetic_parser::{
     create_span_ref, BinaryOp, Grammar, LvalueLen, Op, Span, Spanned, UnaryOp,
@@ -131,7 +132,7 @@ impl<'a, T: Grammar> InterpretedFn<'a, T> {
 impl<'a, T> InterpretedFn<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     /// Evaluates this function with the provided arguments and the execution context.
     pub fn evaluate(
@@ -195,7 +196,7 @@ impl<'a, T: Grammar> Function<'a, T> {
 impl<'a, T> Function<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     /// Evaluates the function on the specified arguments.
     pub fn evaluate(
@@ -405,7 +406,7 @@ impl BinaryOpError {
 impl<'a, T> Value<'a, T>
 where
     T: Grammar,
-    T::Lit: Num + ops::Neg<Output = T::Lit> + Pow<T::Lit, Output = T::Lit>,
+    T::Lit: Number,
 {
     fn try_binary_op_inner(
         self,


### PR DESCRIPTION
- [x] Constructor for `Interpreter` which adds all functions defined in `fns` module (except for `Compare`)
- [x] Ergonomic way of adding function wrappers to interpreter
- [x] Relaxed lifetime bounds for `Interpreter::insert_var()`

closes #6, closes #8, closes #14