### PR TITLE
Implement order comparisons

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -153,14 +153,6 @@ impl<'a> Env<'a> {
                 labels.push(call_label);
                 call_site = call.call_span;
             }
-
-            let (file_id, call_range) = self
-                .code_map
-                .locate(&call_site)
-                .expect("Cannot locate span in previously recorded snippets");
-            let call_label =
-                Label::secondary(file_id, call_range).with_message("...which was called from here");
-            labels.push(call_label);
         }
 
         let mut diagnostic = Diagnostic::new(severity)

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -123,6 +123,21 @@ pub enum EvalError {
         /// Operation which failed.
         op: Op,
     },
+
+    /// Missing comparison function.
+    #[display(fmt = "Missing comparison function {}", name)]
+    MissingCmpFunction {
+        /// Expected function name.
+        name: String,
+    },
+
+    /// Unexpected result of a comparison function invocation. The comparison function should
+    /// always return -1, 0, or 1.
+    #[display(
+        fmt = "Unexpected result of a comparison function invocation. The comparison function \
+            should only return -1, 0, or 1."
+    )]
+    InvalidCmpResult,
 }
 
 impl EvalError {
@@ -150,6 +165,8 @@ impl EvalError {
             Self::NativeCall(message) => message.to_owned(),
             Self::Wrapper(err) => err.to_string(),
             Self::UnexpectedOperand { op } => format!("Unexpected operand type for {}", op),
+            Self::MissingCmpFunction { .. } => "Missing comparison function".to_owned(),
+            Self::InvalidCmpResult => "Invalid comparison result".to_owned(),
         }
     }
 
@@ -165,6 +182,10 @@ impl EvalError {
             Self::Undefined(_) => "Undefined variable occurrence".to_owned(),
             Self::CannotCall | Self::NativeCall(_) | Self::Wrapper(_) => "Failed call".to_owned(),
             Self::UnexpectedOperand { .. } => "Operand of wrong type".to_owned(),
+            Self::MissingCmpFunction { name } => {
+                format!("Function with name {} should exist in the context", name)
+            }
+            Self::InvalidCmpResult => "Comparison function must return -1, 0 or 1".to_owned(),
         }
     }
 

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -632,6 +632,7 @@ mod tests {
     use crate::Interpreter;
 
     use arithmetic_parser::{grammars::F32Grammar, GrammarExt, Span};
+    use assert_matches::assert_matches;
 
     use core::f32;
 
@@ -657,6 +658,28 @@ mod tests {
         let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
         let ret = interpreter.evaluate(&block).unwrap();
         assert_eq!(ret, Value::Number(-1.5));
+    }
+
+    #[test]
+    fn cmp_sugar() {
+        let mut interpreter = Interpreter::new();
+        interpreter.insert_native_fn("cmp", Compare);
+
+        let program = "x = 1.0; x > 0 && x <= 3";
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let ret = interpreter.evaluate(&block).unwrap();
+        assert_eq!(ret, Value::Bool(true));
+
+        let program = "x = 1.0; x > (1, 2)";
+        let block = F32Grammar::parse_statements(Span::new(program)).unwrap();
+        let err = interpreter.evaluate(&block).unwrap_err();
+        assert_matches!(
+            err.source(),
+            EvalError::NativeCall(ref message) if message.contains("Compare requires")
+        );
+        assert_eq!(*err.main_span().fragment(), "x > (1, 2)");
+        assert_eq!(err.aux_spans().len(), 1);
+        assert_eq!(*err.aux_spans()[0].fragment(), "(1, 2)");
     }
 
     #[test]

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -597,7 +597,7 @@ where
 #[derive(Debug, Clone, Copy)]
 pub struct Compare;
 
-const COMPARE_ERROR_MSG: &str = "Compare requires 2 primitive arguments";
+const COMPARE_ERROR_MSG: &str = "Compare requires 2 number arguments";
 
 impl<'a, T> NativeFn<'a, T> for Compare
 where

--- a/eval/src/fns/wrapper.rs
+++ b/eval/src/fns/wrapper.rs
@@ -1,11 +1,12 @@
-use arithmetic_parser::{create_span_ref, Grammar};
+use num_traits::{One, Zero};
 
-use core::{fmt, marker::PhantomData};
+use core::{cmp, fmt, marker::PhantomData};
 
 use crate::{
     AuxErrorInfo, CallContext, EvalError, EvalResult, Function, NativeFn, Number, SpannedEvalError,
     SpannedValue, Value, ValueType,
 };
+use arithmetic_parser::{create_span_ref, Grammar};
 
 /// Wraps a function enriching it with the information about its arguments.
 /// This is a slightly shorter way to create wrappers compared to calling [`FnWrapper::new()`].
@@ -476,6 +477,20 @@ impl<'a, G: Grammar> IntoEvalResult<'a, G> for () {
 impl<'a, G: Grammar> IntoEvalResult<'a, G> for bool {
     fn into_eval_result(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
         Ok(Value::Bool(self))
+    }
+}
+
+impl<'a, G> IntoEvalResult<'a, G> for cmp::Ordering
+where
+    G: Grammar,
+    G::Lit: Number,
+{
+    fn into_eval_result(self) -> Result<Value<'a, G>, ErrorOutput<'a>> {
+        Ok(Value::Number(match self {
+            Self::Less => -<G::Lit as One>::one(),
+            Self::Equal => <G::Lit as Zero>::zero(),
+            Self::Greater => <G::Lit as One>::one(),
+        }))
     }
 }
 

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -28,10 +28,17 @@
 //! - Type annotations are completely ignored. This means that the interpreter may execute
 //!   code that is incorrect with annotations (e.g., assignment of a tuple to a variable which
 //!   is annotated to have a numeric type).
+//! - Order comparisons (`>`, `<`, `>=`, `<=`) are desugared as follows. First, the `cmp` function
+//!   is called with LHS and RHS as args (in this order). The result is then interpreted as
+//!   [`Ordering`] (-1 is `Less`, 1 is `Greater`, 0 is `Equal`; anything else leads to an error).
+//!   Finally, the `Ordering` is used to compute the original comparison operation. For example,
+//!   if `cmp(x, y) == -1`, then `x < y` and `x <= y` will return `true`, and `x > y` will
+//!   return `false`.
 //!
 //! [`arithmetic-parser`]: https://crates.io/crates/arithmetic-parser
 //! [`Interpreter`]: struct.Interpreter.html
 //! [`Value`]: enum.Value.html
+//! [`Ordering`]: https://doc.rust-lang.org/std/cmp/enum.Ordering.html
 //!
 //! # Examples
 //!

--- a/eval/tests/custom_cmp.rs
+++ b/eval/tests/custom_cmp.rs
@@ -1,0 +1,44 @@
+//! Demonstrates how to use custom comparison functions.
+
+use num_complex::Complex64;
+
+use core::cmp::Ordering;
+
+use arithmetic_eval::Interpreter;
+use arithmetic_parser::{grammars::NumGrammar, GrammarExt, Span};
+
+const PROGRAM: &str = r#"
+    # The original comparison function compares numbers by their real part.
+    assert(1 > -1);
+    assert(-1 + 2i < 1 + i);
+
+    # This function will capture the original comparison function.
+    is_positive = |x| x > 0;
+    assert(is_positive(1));
+    assert(!is_positive(-1));
+    assert(!is_positive(0));
+
+    # Override the comparison function so that it compares imaginary parts of numbers.
+    # It immediately influences all following comparisons.
+    cmp = |x, y| cmp(-i * x, -i * y);
+    assert(!(1 > -1));
+    assert(-1 + 2i >= 1 + i);
+
+    # ...but does not influence the comparisons in `is_positive`.
+    assert(is_positive(1 - i) && !is_positive(-1 + 2i));
+"#;
+
+type ComplexGrammar = NumGrammar<Complex64>;
+
+#[test]
+fn custom_cmp_function() {
+    let mut interpreter = Interpreter::<ComplexGrammar>::with_prelude();
+    // There is no "natural" comparison function on complex numbers. Here, we'll define one
+    // using comparison of real parts.
+    interpreter.insert_wrapped_fn("cmp", |x: Complex64, y: Complex64| {
+        x.re.partial_cmp(&y.re).unwrap_or(Ordering::Equal)
+    });
+
+    let block = ComplexGrammar::parse_statements(Span::new(PROGRAM)).unwrap();
+    interpreter.evaluate(&block).unwrap();
+}

--- a/parser/README.md
+++ b/parser/README.md
@@ -42,6 +42,9 @@ These features can be switched on or off when defining a grammar.
 - **Type annotations.** A type annotation in the form `var: Type` can be present
   in the lvalues or in the function argument definitions. The parser for type annotations
   is user-defined.
+- **Order comparisons,** that is, `>`, `<`, `>=`, and `<=` boolean ops.
+  (The reason is that these ops do not make sense for some grammars, 
+  such as for modular arithmetic.)
 
 ### Code Sample
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -338,21 +338,33 @@ pub enum BinaryOp {
     And,
     /// Boolean OR (`||`).
     Or,
+    /// "Greater than" comparison.
+    Gt,
+    /// "Lesser than" comparison.
+    Lt,
+    /// "Greater or equal" comparison.
+    Ge,
+    /// "Lesser or equal" comparison.
+    Le,
 }
 
 impl fmt::Display for BinaryOp {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Add => formatter.write_str("addition"),
-            Self::Sub => formatter.write_str("subtraction"),
-            Self::Mul => formatter.write_str("multiplication"),
-            Self::Div => formatter.write_str("division"),
-            Self::Power => formatter.write_str("exponentiation"),
-            Self::Eq => formatter.write_str("comparison"),
-            Self::NotEq => formatter.write_str("non-equality comparison"),
-            Self::And => formatter.write_str("AND"),
-            Self::Or => formatter.write_str("OR"),
-        }
+        formatter.write_str(match self {
+            Self::Add => "addition",
+            Self::Sub => "subtraction",
+            Self::Mul => "multiplication",
+            Self::Div => "division",
+            Self::Power => "exponentiation",
+            Self::Eq => "equality comparison",
+            Self::NotEq => "non-equality comparison",
+            Self::And => "AND",
+            Self::Or => "OR",
+            Self::Gt => "greater comparison",
+            Self::Lt => "lesser comparison",
+            Self::Ge => "greater-or-equal comparison",
+            Self::Le => "lesser-or-equal comparison",
+        })
     }
 }
 
@@ -369,6 +381,10 @@ impl BinaryOp {
             Self::NotEq => "!=",
             Self::And => "&&",
             Self::Or => "||",
+            Self::Gt => ">",
+            Self::Lt => "<",
+            Self::Ge => ">=",
+            Self::Le => "<=",
         }
     }
 
@@ -377,7 +393,7 @@ impl BinaryOp {
     pub fn priority(self) -> usize {
         match self {
             Self::And | Self::Or => 0,
-            Self::Eq | Self::NotEq => 1,
+            Self::Eq | Self::NotEq | Self::Gt | Self::Lt | Self::Le | Self::Ge => 1,
             Self::Add | Self::Sub => 2,
             Self::Mul | Self::Div => 3,
             Self::Power => 4,
@@ -395,7 +411,15 @@ impl BinaryOp {
     /// Checks if this operation is a comparison.
     pub fn is_comparison(self) -> bool {
         match self {
-            Self::Eq | Self::NotEq => true,
+            Self::Eq | Self::NotEq | Self::Gt | Self::Lt | Self::Le | Self::Ge => true,
+            _ => false,
+        }
+    }
+
+    /// Checks if this operation is an order comparison.
+    pub fn is_order_comparison(self) -> bool {
+        match self {
+            Self::Gt | Self::Lt | Self::Le | Self::Ge => true,
             _ => false,
         }
     }

--- a/parser/src/traits.rs
+++ b/parser/src/traits.rs
@@ -19,6 +19,8 @@ pub struct Features {
     pub blocks: bool,
     /// Parse methods?
     pub methods: bool,
+    /// Parse order comparison operations (`>`, `<`, `>=`, `<=`)?
+    pub order_comparisons: bool,
 }
 
 impl Features {
@@ -30,6 +32,7 @@ impl Features {
             fn_definitions: true,
             blocks: true,
             methods: true,
+            order_comparisons: true,
         }
     }
 
@@ -41,6 +44,7 @@ impl Features {
             fn_definitions: false,
             blocks: false,
             methods: false,
+            order_comparisons: false,
         }
     }
 }


### PR DESCRIPTION
This PR implements order comparisons (`>`, `<`, `>=`, `<=`). The `eval` crate desugars these comparisons into calls to `cmp` function.

closes #4