### PR TITLE
Use owned `ExecutableModule` in CLI crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,6 @@ codespan-reporting = "0.9.0"
 num-complex = "0.3.0"
 rustyline = "6.0.0"
 structopt = "0.3.13"
-typed-arena = "2.0.1"
 unindent = "0.1.6"
 
 [dependencies.arithmetic-parser]

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -10,57 +10,98 @@ use num_complex::{Complex, Complex32, Complex64};
 use unindent::unindent;
 
 use std::{
-    collections::BTreeMap,
     fmt,
     io::{self, Write},
     ops::Range,
 };
 
 use arithmetic_eval::{
-    fns, BacktraceElement, ErrorWithBacktrace, Function, Interpreter, Number, Value,
+    fns, BacktraceElement, ErrorWithBacktrace, Function, Interpreter, ModuleId, Number,
+    SpannedEvalError, Value,
 };
 use arithmetic_parser::{
-    grammars::NumGrammar, CodeFragment, Error, Grammar, GrammarExt, InputSpan, LocatedSpan, Spanned,
+    grammars::NumGrammar, Block, CodeFragment, Error, Grammar, GrammarExt, InputSpan, LocatedSpan,
+    LvalueLen, Spanned,
 };
 
 /// Exit code on parse or evaluation error.
 pub const ERROR_EXIT_CODE: i32 = 2;
 
-/// Code map containing evaluated code snippets.
-#[derive(Debug, Default)]
-pub struct CodeMap<'a> {
-    files: Files<&'a str>,
-    code_positions: BTreeMap<usize, FileId>,
-    next_position: usize,
+/// Snippet ID.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Snippet(usize);
+
+impl fmt::Display for Snippet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Snippet #{}", self.0 + 1)
+    }
 }
 
-impl<'a> CodeMap<'a> {
-    fn add(&mut self, source: &'a str) -> (FileId, usize) {
-        let file_name = format!("Snip #{}", self.code_positions.len() + 1);
+impl ModuleId for Snippet {
+    fn clone_boxed(&self) -> Box<dyn ModuleId> {
+        Box::new(*self)
+    }
+}
+
+/// Helper trait for possible `LocationSpan.fragment` types.
+trait SizedFragment {
+    fn fragment_len(&self) -> usize;
+}
+
+impl SizedFragment for &str {
+    fn fragment_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl SizedFragment for CodeFragment<'_> {
+    fn fragment_len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// Code map containing evaluated code snippets.
+#[derive(Debug, Default)]
+pub struct CodeMap {
+    files: Files<String>,
+    file_ids: Vec<FileId>, // necessary because `FileId` is opaque
+}
+
+impl CodeMap {
+    fn add(&mut self, source: String) -> FileId {
+        let file_name = Snippet(self.file_ids.len()).to_string();
         let file_id = self.files.add(file_name, source);
-        let start_position = self.next_position;
-        self.code_positions.insert(start_position, file_id);
-        self.next_position += source.len();
-        (file_id, start_position)
+        self.file_ids.push(file_id);
+        file_id
     }
 
-    fn locate<Span, T>(&self, span: &LocatedSpan<Span, T>) -> Option<(FileId, Range<usize>)>
-    where
-        Span: Copy,
-        CodeFragment<'a>: From<Span>,
-    {
-        if span.location_offset() > self.next_position {
-            return None;
-        }
-        let (&file_start, &file_id) = self
-            .code_positions
-            .range(..=span.location_offset())
-            .rev()
-            .next()?;
-        let start = span.location_offset() - file_start;
-        let code = CodeFragment::from(*span.fragment());
-        let range = start..(start + code.len());
-        Some((file_id, range))
+    fn locate<Span: SizedFragment, T>(
+        &self,
+        module_id: &dyn ModuleId,
+        span: &LocatedSpan<Span, T>,
+    ) -> (FileId, Range<usize>) {
+        let snippet = module_id
+            .downcast_ref::<Snippet>()
+            .expect("Module ID is not a Snippet");
+        let file_id = self.file_ids[snippet.0];
+
+        let start = span.location_offset();
+        let range = start..(start + span.fragment().fragment_len());
+        (file_id, range)
+    }
+
+    fn locate_in_most_recent_file<Span: SizedFragment, T>(
+        &self,
+        span: &LocatedSpan<Span, T>,
+    ) -> (FileId, Range<usize>) {
+        let file_id = *self.file_ids.last().expect("No files");
+        let start = span.location_offset();
+        let range = start..(start + span.fragment().fragment_len());
+        (file_id, range)
+    }
+
+    fn latest_module_id(&self) -> Snippet {
+        Snippet(self.file_ids.len() - 1)
     }
 }
 
@@ -81,13 +122,13 @@ impl<T> ParseAndEvalResult<T> {
     }
 }
 
-pub struct Env<'a> {
-    code_map: CodeMap<'a>,
+pub struct Env {
+    code_map: CodeMap,
     writer: StandardStream,
     config: ReportingConfig,
 }
 
-impl<'a> Env<'a> {
+impl Env {
     pub fn new() -> Self {
         Self {
             code_map: CodeMap::default(),
@@ -96,10 +137,11 @@ impl<'a> Env<'a> {
         }
     }
 
-    pub fn non_interactive(code: &'a str) -> Self {
+    pub fn non_interactive(code: String) -> (Self, Snippet) {
         let mut this = Self::new();
         this.code_map.add(code);
-        this
+        let snippet = this.code_map.latest_module_id();
+        (this, snippet)
     }
 
     pub fn print_greeting(&mut self) -> io::Result<()> {
@@ -150,10 +192,9 @@ impl<'a> Env<'a> {
 
     /// Reports a parsing error.
     pub fn report_parse_error(&self, err: Spanned<'_, Error<'_>>) -> io::Result<()> {
-        let (file, range) = self
-            .code_map
-            .locate(&err)
-            .expect("Cannot locate parse error span");
+        // Parsing errors are always reported for the most recently added snippet.
+        let (file, range) = self.code_map.locate_in_most_recent_file(&err);
+
         let label = Label::primary(file, range).with_message("Error occurred here");
         let diagnostic = Diagnostic::error()
             .with_message(err.extra.to_string())
@@ -168,60 +209,61 @@ impl<'a> Env<'a> {
         )
     }
 
-    pub fn report_eval_error(&self, e: ErrorWithBacktrace) -> io::Result<()> {
-        let severity = Severity::Error;
+    fn create_diagnostic(&self, e: &SpannedEvalError<'_>) -> Diagnostic<FileId> {
+        let main_span = e.main_span();
         let (file, range) = self
             .code_map
-            .locate(&e.main_span())
-            .expect("Cannot locate main error span");
+            .locate(main_span.module_id(), main_span.code());
         let main_label = Label::primary(file, range);
-        let message = e.source().main_span_info();
+        let message = e.kind().main_span_info();
 
         let mut labels = vec![main_label.with_message(message)];
         for aux_span in e.aux_spans() {
-            let (file, range) = self
-                .code_map
-                .locate(&aux_span)
-                .expect("Cannot locate aux error span");
-            let label = Label::primary(file, range).with_message(aux_span.extra.to_string());
+            let (file, range) = self.code_map.locate(aux_span.module_id(), aux_span.code());
+            let label = Label::primary(file, range).with_message(aux_span.code().extra.to_string());
             labels.push(label);
         }
 
-        let mut calls_iter = e.backtrace().calls();
-        if let Some(BacktraceElement {
-            fn_name, def_span, ..
-        }) = calls_iter.next()
-        {
-            if let Some(def_span) = def_span {
-                let (file_id, def_range) = self
-                    .code_map
-                    .locate(&def_span.span())
-                    .expect("Cannot locate span in previously recorded snippets");
-                let def_label = Label::secondary(file_id, def_range)
-                    .with_message(format!("The error occurred in function `{}`", fn_name));
-                labels.push(def_label);
-            }
-
-            let mut call_site;
-            for (depth, call) in calls_iter.enumerate() {
-                call_site = call.call_span;
-                let (file_id, call_range) = self
-                    .code_map
-                    .locate(&call_site.span())
-                    .expect("Cannot locate span in previously recorded snippets");
-                let call_label = Label::secondary(file_id, call_range)
-                    .with_message(format!("Call at depth {}", depth + 1));
-                labels.push(call_label);
-            }
-        }
-
-        let mut diagnostic = Diagnostic::new(severity)
-            .with_message(e.source().to_short_string())
+        let mut diagnostic = Diagnostic::new(Severity::Error)
+            .with_message(e.kind().to_short_string())
             .with_code("EVAL")
             .with_labels(labels);
 
-        if let Some(help) = e.source().help() {
+        if let Some(help) = e.kind().help() {
             diagnostic = diagnostic.with_notes(vec![help]);
+        }
+
+        diagnostic
+    }
+
+    pub fn report_eval_error(&self, e: ErrorWithBacktrace<'_>) -> io::Result<()> {
+        let mut diagnostic = self.create_diagnostic(e.source());
+
+        let mut calls_iter = e.backtrace().calls();
+        if let Some(BacktraceElement {
+            fn_name,
+            def_span,
+            mut call_span,
+            ..
+        }) = calls_iter.next()
+        {
+            if let Some(def_span) = def_span {
+                let (file_id, def_range) =
+                    self.code_map.locate(def_span.module_id(), &def_span.code());
+                let def_label = Label::secondary(file_id, def_range)
+                    .with_message(format!("The error occurred in function `{}`", fn_name));
+                diagnostic.labels.push(def_label);
+            }
+
+            for (depth, call) in calls_iter.enumerate() {
+                call_span = call.call_span;
+                let (file_id, call_range) = self
+                    .code_map
+                    .locate(call_span.module_id(), &call_span.code());
+                let call_label = Label::secondary(file_id, call_range)
+                    .with_message(format!("Call at depth {}", depth + 1));
+                diagnostic.labels.push(call_label);
+            }
         }
 
         emit(
@@ -259,7 +301,13 @@ impl<'a> Env<'a> {
             Value::Function(Function::Native(_)) => write!(self.writer, "(native fn)"),
 
             Value::Function(Function::Interpreted(function)) => {
-                write!(self.writer, "fn({} args)", function.arg_count())?;
+                let plurality = if function.arg_count() == LvalueLen::Exact(1) {
+                    ""
+                } else {
+                    "s"
+                };
+                write!(self.writer, "fn({} arg{})", function.arg_count(), plurality)?;
+
                 let captures = function.captures();
                 if !captures.is_empty() {
                     writeln!(self.writer, "[")?;
@@ -303,8 +351,8 @@ impl<'a> Env<'a> {
 
     fn dump_scope<T>(
         &mut self,
-        scope: &Interpreter<'a, T>,
-        original_scope: &Interpreter<'a, T>,
+        scope: &Interpreter<'_, T>,
+        original_scope: &Interpreter<'_, T>,
         dump_original_scope: bool,
     ) -> io::Result<()>
     where
@@ -326,9 +374,9 @@ impl<'a> Env<'a> {
         Ok(())
     }
 
-    pub fn parse_and_eval<T>(
+    pub fn parse_and_eval<'a, T>(
         &mut self,
-        line: &'a str,
+        line: &str,
         interpreter: &mut Interpreter<'a, T>,
         original_interpreter: &Interpreter<'a, T>,
     ) -> io::Result<ParseAndEvalResult>
@@ -336,42 +384,14 @@ impl<'a> Env<'a> {
         T: Grammar,
         T::Lit: fmt::Display + Number,
     {
-        let (file, start_position) = self.code_map.add(line);
-        let visible_span = 0..line.len();
+        self.code_map.add(line.to_owned());
 
         if line.starts_with('.') {
-            match line {
-                ".clear" => interpreter.clone_from(original_interpreter),
-                ".dump" => self.dump_scope(interpreter, original_interpreter, false)?,
-                ".dump all" => self.dump_scope(interpreter, original_interpreter, true)?,
-                ".help" => self.print_help()?,
-
-                _ => {
-                    let label = Label::primary(file, visible_span)
-                        .with_message("Use `.help commands` to find out commands");
-                    let diagnostic = Diagnostic::error()
-                        .with_message("Unknown command")
-                        .with_code("CMD")
-                        .with_labels(vec![label]);
-
-                    emit(
-                        &mut self.writer.lock(),
-                        &self.config,
-                        &self.code_map.files,
-                        &diagnostic,
-                    )?;
-                }
-            }
-
+            self.process_command(line, interpreter, original_interpreter)?;
             return Ok(ParseAndEvalResult::Ok(()));
         }
 
-        let span = unsafe {
-            // SAFETY: We do not traverse the portion of the program preceding the `span`
-            // (this could lead to UB since `line` is not necessarily sliced from a larger program).
-            // Instead, the span offset is used for diagnostic messages only.
-            InputSpan::new_from_raw_offset(start_position, 1, line, ())
-        };
+        let span = InputSpan::new(line);
         let parse_result = T::parse_streaming_statements(span)
             .map(ParseAndEvalResult::Ok)
             .or_else(|e| {
@@ -384,21 +404,72 @@ impl<'a> Env<'a> {
             })?;
 
         Ok(if let ParseAndEvalResult::Ok(statements) = parse_result {
-            match interpreter.evaluate(&statements) {
-                Ok(value) => {
-                    if !value.is_void() {
-                        self.dump_value(&value, 0)?;
-                    }
-                    ParseAndEvalResult::Ok(())
-                }
-                Err(err) => {
-                    self.report_eval_error(err)?;
-                    ParseAndEvalResult::Errored
-                }
-            }
+            self.compile_and_execute(&statements, interpreter)?
         } else {
             parse_result.map(drop)
         })
+    }
+
+    fn process_command<'a, T>(
+        &mut self,
+        line: &str,
+        interpreter: &mut Interpreter<'a, T>,
+        original_interpreter: &Interpreter<'a, T>,
+    ) -> io::Result<()>
+    where
+        T: Grammar,
+        T::Lit: fmt::Display + Number,
+    {
+        let file_id = *self.code_map.file_ids.last().expect("no files");
+
+        match line {
+            ".clear" => interpreter.clone_from(original_interpreter),
+            ".dump" => self.dump_scope(interpreter, original_interpreter, false)?,
+            ".dump all" => self.dump_scope(interpreter, original_interpreter, true)?,
+            ".help" => self.print_help()?,
+
+            _ => {
+                let label = Label::primary(file_id, 0..line.len())
+                    .with_message("Use `.help commands` to find out commands");
+                let diagnostic = Diagnostic::error()
+                    .with_message("Unknown command")
+                    .with_code("CMD")
+                    .with_labels(vec![label]);
+
+                emit(
+                    &mut self.writer.lock(),
+                    &self.config,
+                    &self.code_map.files,
+                    &diagnostic,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn compile_and_execute<'a, T>(
+        &mut self,
+        statements: &Block<'_, T>,
+        interpreter: &mut Interpreter<'a, T>,
+    ) -> io::Result<ParseAndEvalResult>
+    where
+        T: Grammar,
+        T::Lit: fmt::Display + Number,
+    {
+        let module_id = self.code_map.latest_module_id();
+        let value = match interpreter.evaluate_named(module_id, statements) {
+            Ok(value) => value,
+            Err(err) => {
+                self.report_eval_error(err)?;
+                return Ok(ParseAndEvalResult::Errored);
+            }
+        };
+
+        if !value.is_void() {
+            self.dump_value(&value, 0)?;
+        }
+        Ok(ParseAndEvalResult::Ok(()))
     }
 }
 

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -195,7 +195,7 @@ impl<'a> Env<'a> {
             if let Some(def_span) = def_span {
                 let (file_id, def_range) = self
                     .code_map
-                    .locate(&def_span)
+                    .locate(&def_span.span())
                     .expect("Cannot locate span in previously recorded snippets");
                 let def_label = Label::secondary(file_id, def_range)
                     .with_message(format!("The error occurred in function `{}`", fn_name));
@@ -207,7 +207,7 @@ impl<'a> Env<'a> {
                 call_site = call.call_span;
                 let (file_id, call_range) = self
                     .code_map
-                    .locate(&call_site)
+                    .locate(&call_site.span())
                     .expect("Cannot locate span in previously recorded snippets");
                 let call_label = Label::secondary(file_id, call_range)
                     .with_message(format!("Call at depth {}", depth + 1));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,10 +101,12 @@ impl Args {
             Ok(())
         } else {
             let mut interpreter = T::create_interpreter();
-            let value = interpreter.evaluate_named(snippet, &parsed).or_else(|e| {
-                env.report_eval_error(e)
-                    .map(|()| process::exit(ERROR_EXIT_CODE))
-            })?;
+            let value = interpreter
+                .evaluate_named_block(snippet, &parsed)
+                .or_else(|e| {
+                    env.report_eval_error(e)
+                        .map(|()| process::exit(ERROR_EXIT_CODE))
+                })?;
             env.writeln_value(&value)
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -88,7 +88,7 @@ impl Args {
 
     fn run_command<T: ReplLiteral>(self) -> io::Result<()> {
         let command = self.command.unwrap_or_default();
-        let mut env = Env::non_interactive(&command);
+        let (mut env, snippet) = Env::non_interactive(command.clone());
 
         let command = InputSpan::new(&command);
         let parsed = NumGrammar::<T>::parse_statements(command).or_else(|e| {
@@ -101,7 +101,7 @@ impl Args {
             Ok(())
         } else {
             let mut interpreter = T::create_interpreter();
-            let value = interpreter.evaluate(&parsed).or_else(|e| {
+            let value = interpreter.evaluate_named(snippet, &parsed).or_else(|e| {
                 env.report_eval_error(e)
                     .map(|()| process::exit(ERROR_EXIT_CODE))
             })?;

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -1,7 +1,6 @@
 //! REPL for arithmetic expressions.
 
 use rustyline::{error::ReadlineError, Editor};
-use typed_arena::Arena;
 
 use std::io;
 
@@ -12,7 +11,6 @@ pub fn repl<T: ReplLiteral>() -> io::Result<()> {
     let mut env = Env::new();
     env.print_greeting()?;
 
-    let snippet_arena = Arena::new();
     let mut interpreter = T::create_interpreter();
     let original_interpreter = interpreter.clone();
     let mut snippet = String::new();
@@ -23,9 +21,7 @@ pub fn repl<T: ReplLiteral>() -> io::Result<()> {
         match line {
             Ok(line) => {
                 snippet.push_str(&line);
-                let arena_ref = &*snippet_arena.alloc(snippet.clone());
-                let result =
-                    env.parse_and_eval(arena_ref, &mut interpreter, &original_interpreter)?;
+                let result = env.parse_and_eval(&line, &mut interpreter, &original_interpreter)?;
                 match result {
                     ParseAndEvalResult::Ok(_) => {
                         prompt = ">>> ";

--- a/cli/tests/cli_expectations.rs
+++ b/cli/tests/cli_expectations.rs
@@ -42,7 +42,7 @@ fn outputting_interpreted_function() {
 fn syntax_error() {
     const EXPECTED_ERR: &str = r#"
         error[PARSE]: Uninterpreted characters after parsing
-          ┌─ Snip #1:1:5
+          ┌─ Snippet #1:1:5
           │
         1 │ let x = 5
           │     ^^^^^ Error occurred here
@@ -59,7 +59,7 @@ fn syntax_error() {
 fn undefined_variable_error() {
     const EXPECTED_ERR: &str = r#"
         error[EVAL]: Variable `x` is not defined
-          ┌─ Snip #1:1:9
+          ┌─ Snippet #1:1:9
           │
         1 │ 1 + 2 * x
           │         ^ Undefined variable occurrence
@@ -76,7 +76,7 @@ fn undefined_variable_error() {
 fn incompatible_arg_count_error() {
     const EXPECTED_ERR: &str = r#"
         error[EVAL]: Mismatch between the number of arguments in the function definition and its call
-          ┌─ Snip #1:1:1
+          ┌─ Snippet #1:1:1
           │
         1 │ if(2 > 1, 3)
           │ ^^^^^^^^^^^^ Called with 2 arg(s) here
@@ -97,7 +97,7 @@ fn error_with_call_trace() {
     "#;
     const EXPECTED_ERR: &str = r#"
         error[EVAL]: Compare requires 2 number arguments
-          ┌─ Snip #1:1:19
+          ┌─ Snippet #1:1:19
           │
         1 │ is_positive = |x| x > 0;
           │                   ^^^^^
@@ -123,7 +123,7 @@ fn error_with_call_complex_call_trace() {
     "#;
     const EXPECTED_ERR: &str = r#"
         error[EVAL]: Compare requires 2 number arguments
-          ┌─ Snip #1:1:26
+          ┌─ Snippet #1:1:26
           │
         1 │ all = |array, predicate| array.fold(true, |acc, x| acc && predicate(x));
           │                          ----------------------------------------------

--- a/cli/tests/cli_expectations.rs
+++ b/cli/tests/cli_expectations.rs
@@ -35,7 +35,7 @@ fn outputting_interpreted_function() {
     let assert = create_command(PROGRAM).assert();
     assert
         .success()
-        .stderr("fn(1 args)[\n  > = (native fn)\n]\n");
+        .stderr("fn(1 arg)[\n  cmp = (native fn)\n]\n");
 }
 
 #[test]

--- a/eval/CHANGELOG.md
+++ b/eval/CHANGELOG.md
@@ -24,7 +24,9 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 - Make most enums and structs with public fields non-exhaustive (e.g., error types,
   `Value`). (#26)
 
-- Rename error types: `EvalError` to `ErrorKind`, `SpannedEvalError` to `Error`. (#31)
+- Rename error types: `EvalError` to `ErrorKind`, `SpannedEvalError` to `Error`.
+  Make the `error` module public and only re-export the most used types from it
+  to the crate root. (#31)
 
 - Move getters such as `main_span()` from `ErrorWithBacktrace` to `Error`, which
   can be accessed via `source()`. (#31)
@@ -34,7 +36,7 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Make the interpreter methods that both compile and run code return
   a new error type, `InterpreterError`. This allows distinguishing between
-  these error kinds and eliminates "fake" backtrace for compile-time errors. (#31)
+  these error kinds and eliminates a "fake" backtrace for compile-time errors. (#31)
 
 ## 0.2.0-beta.1 - 2020-10-04
 

--- a/eval/CHANGELOG.md
+++ b/eval/CHANGELOG.md
@@ -12,12 +12,29 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Implement `while` as a native function. (#26)
 
+- Add IDs for executable modules. These IDs can be used to locate code spans for errors
+  and interpreted functions. (#31)
+
+- Allow evaluating blocks with any lifetime against the interpreter. (#31)
+
 ### Changed
 
 - Change APIs related to code spans according to the updates in the parser crate. (#26)
 
 - Make most enums and structs with public fields non-exhaustive (e.g., error types,
   `Value`). (#26)
+
+- Rename error types: `EvalError` to `ErrorKind`, `SpannedEvalError` to `Error`. (#31)
+
+- Move getters such as `main_span()` from `ErrorWithBacktrace` to `Error`, which
+  can be accessed via `source()`. (#31)
+
+- Make `Backtrace` type crate-private; move backtrace call iterator
+  directly to `ErrorWithBacktrace`. (#31)
+
+- Make the interpreter methods that both compile and run code return
+  a new error type, `InterpreterError`. This allows distinguishing between
+  these error kinds and eliminates "fake" backtrace for compile-time errors. (#31)
 
 ## 0.2.0-beta.1 - 2020-10-04
 

--- a/eval/benches/interpreter.rs
+++ b/eval/benches/interpreter.rs
@@ -9,7 +9,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Bencher, Criterion, 
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use typed_arena::Arena;
 
-use arithmetic_eval::{fns, CallContext, Interpreter, NativeFn, Value};
+use arithmetic_eval::{fns, CallContext, Interpreter, NativeFn, Value, WildcardId};
 use arithmetic_parser::{grammars::F32Grammar, GrammarExt, InputSpan};
 
 const SEED: u64 = 123;
@@ -62,7 +62,7 @@ fn bench_mul(bencher: &mut Bencher<'_>) {
                 .collect();
             let program = arena.alloc(values.join(" * "));
             let program = F32Grammar::parse_statements(InputSpan::new(program)).unwrap();
-            Interpreter::new().compile(&program).unwrap()
+            Interpreter::new().compile(WildcardId, &program).unwrap()
         },
         |block| block.run().unwrap(),
         BatchSize::SmallInput,
@@ -80,7 +80,7 @@ fn bench_mul_fold(bencher: &mut Bencher<'_>) {
             let mut module = interpreter
                 .insert_native_fn("fold", fns::Fold)
                 .insert_var("xs", Value::Tuple(vec![]))
-                .compile(&program)
+                .compile(WildcardId, &program)
                 .unwrap();
 
             let values: Vec<_> = (0..ELEMENTS)

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -63,13 +63,16 @@ fn main() -> anyhow::Result<()> {
     let err = bogus_module.run_with_imports(imports).unwrap_err();
     println!("Expected error:\n{:#}", err);
     assert_matches!(
-        err.source(),
+        err.source().kind(),
         EvalError::UnexpectedOperand { op } if *op == BinaryOp::Add.into()
     );
 
     // Naturally, spans in the stripped module do not retain refs to source code,
     // but rather contain info sufficient to be recoverable.
-    assert_eq!(err.main_span().code_or_location("call"), "call at 1:34");
+    assert_eq!(
+        err.source().main_span().code().code_or_location("call"),
+        "call at 1:34"
+    );
 
     // Importing into a stripped module also works. Let's redefine the `fold` import.
     let mut imports = sum_module.imports().to_owned();

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -3,7 +3,7 @@
 use anyhow::anyhow;
 use assert_matches::assert_matches;
 
-use arithmetic_eval::{EvalError, ExecutableModule, Interpreter, Value};
+use arithmetic_eval::{ErrorKind, ExecutableModule, Interpreter, Value};
 use arithmetic_parser::{
     grammars::F64Grammar, BinaryOp, GrammarExt, InputSpan, StripCode, StripResultExt,
 };
@@ -64,7 +64,7 @@ fn main() -> anyhow::Result<()> {
     println!("Expected error:\n{:#}", err);
     assert_matches!(
         err.source().kind(),
-        EvalError::UnexpectedOperand { op } if *op == BinaryOp::Add.into()
+        ErrorKind::UnexpectedOperand { op } if *op == BinaryOp::Add.into()
     );
 
     // Naturally, spans in the stripped module do not retain refs to source code,

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -9,6 +9,7 @@ use arithmetic_parser::{
 };
 
 fn create_module<'a>(
+    module_name: &'static str,
     program: &'a str,
     import_name: &str,
 ) -> anyhow::Result<ExecutableModule<'a, F64Grammar>> {
@@ -23,22 +24,23 @@ fn create_module<'a>(
 
     let mut interpreter = Interpreter::with_prelude();
     interpreter.insert_var(import_name, Value::void());
-    Ok(interpreter.compile(&block).strip_err()?)
+    Ok(interpreter.compile(module_name, &block).strip_err()?)
 }
 
 fn create_static_module(
+    module_name: &'static str,
     program: &str,
     import_name: &str,
 ) -> anyhow::Result<ExecutableModule<'static, F64Grammar>> {
     // By default, the module is tied by its lifetime to the `program`. However,
     // we can break this tie using the `StripCode` trait.
-    create_module(program, import_name).map(|module| module.strip_code())
+    create_module(module_name, program, import_name).map(|module| module.strip_code())
 }
 
 fn main() -> anyhow::Result<()> {
     let sum_module = {
         let dynamic_program = String::from("|var| var.fold(0, |acc, x| acc + x)");
-        create_static_module(&dynamic_program, "var")?
+        create_static_module("sum", &dynamic_program, "var")?
         // Ensure that the program is indeed dropped by using a separate scope.
     };
 
@@ -47,13 +49,13 @@ fn main() -> anyhow::Result<()> {
     assert!(sum_fn.is_function());
 
     // Let's import the function into another module and check that it works.
-    let mut test_module = create_module("(1, 2, -5).sum()", "sum")?;
+    let mut test_module = create_module("test", "(1, 2, -5).sum()", "sum")?;
     test_module.set_import("sum", sum_fn.clone());
     let sum_value = test_module.run()?;
     assert_eq!(sum_value, Value::Number(-2.0)); // 1 + 2 - 5
 
     // Errors are handled as well.
-    let bogus_module = create_module("(1, true, -5).sum()", "sum")?;
+    let bogus_module = create_module("bogus", "(1, true, -5).sum()", "sum")?;
     let mut imports = bogus_module.imports().to_owned();
     assert!(imports.contains("sum"));
     imports["sum"] = sum_fn;
@@ -90,7 +92,7 @@ fn main() -> anyhow::Result<()> {
         rfold
     "#;
     let fold_program = String::from(fold_program);
-    let fold_module = create_module(&fold_program, "_")?;
+    let fold_module = create_module("rfold", &fold_program, "_")?;
     let rfold_fn = fold_module.run().strip_err()?;
 
     imports["fold"] = rfold_fn;

--- a/eval/src/compiler.rs
+++ b/eval/src/compiler.rs
@@ -378,11 +378,16 @@ impl Compiler {
         };
 
         let ptr = executable.push_child_fn(fn_executable);
+        let (capture_names, captures) = captures
+            .into_iter()
+            .map(|(name, value)| (name.to_owned(), value))
+            .unzip();
         let register = self.push_assignment(
             executable,
             CompiledExpr::DefineFunction {
                 ptr,
-                captures: captures.into_iter().map(|(_, value)| value).collect(),
+                captures,
+                capture_names,
             },
             def_expr,
         );

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -543,18 +543,13 @@ impl StripCode for BacktraceElement<'_> {
 
 /// Error backtrace.
 #[derive(Debug, Default)]
-pub struct Backtrace<'a> {
+pub(crate) struct Backtrace<'a> {
     calls: Vec<BacktraceElement<'a>>,
 }
 
 impl<'a> Backtrace<'a> {
-    /// Iterates over the backtrace, starting from the most recent call.
-    pub fn calls(&self) -> impl Iterator<Item = BacktraceElement<'a>> + '_ {
-        self.calls.iter().rev().cloned()
-    }
-
     /// Appends a function call into the backtrace.
-    pub(crate) fn push_call(
+    pub fn push_call(
         &mut self,
         fn_name: &str,
         def_span: Option<CodeInModule<'a>>,
@@ -568,7 +563,7 @@ impl<'a> Backtrace<'a> {
     }
 
     /// Pops a function call.
-    pub(crate) fn pop_call(&mut self) {
+    pub fn pop_call(&mut self) {
         self.calls.pop();
     }
 }
@@ -603,9 +598,9 @@ impl<'a> ErrorWithBacktrace<'a> {
         &self.inner
     }
 
-    /// Returns error backtrace.
-    pub fn backtrace(&self) -> &Backtrace<'a> {
-        &self.backtrace
+    /// Iterates over the error backtrace, starting from the most recent call.
+    pub fn backtrace(&self) -> impl Iterator<Item = &BacktraceElement<'a>> + '_ {
+        self.backtrace.calls.iter().rev()
     }
 }
 

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -113,7 +113,7 @@ pub enum ErrorKind {
 
     /// Error while converting arguments for [`FnWrapper`].
     ///
-    /// [`FnWrapper`]: fns/struct.FnWrapper.html
+    /// [`FnWrapper`]: ../fns/struct.FnWrapper.html
     #[display(
         fmt = "Failed converting arguments for native function wrapper: {}",
         _0

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -2,7 +2,10 @@
 
 use core::ops;
 
-use crate::{Backtrace, ErrorWithBacktrace, ModuleId, Number, Value};
+use crate::{
+    error::{Backtrace, ErrorWithBacktrace},
+    ModuleId, Number, Value,
+};
 use arithmetic_parser::{Grammar, LvalueLen, MaybeSpanned, StripCode};
 
 mod command;

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -53,7 +53,7 @@ impl<T: Grammar> StripCode for ExecutableFn<'_, T> {
 ///
 /// let module = "xs.fold(-INFINITY, max)";
 /// let module = F32Grammar::parse_statements(InputSpan::new(module)).unwrap();
-/// let mut module = interpreter.compile(&module).unwrap();
+/// let mut module = interpreter.compile("test", &module).unwrap();
 ///
 /// // With the original imports, the returned value is `-INFINITY`.
 /// assert_eq!(module.run().unwrap(), Value::Number(f32::NEG_INFINITY));
@@ -83,7 +83,7 @@ impl<T: Grammar> StripCode for ExecutableFn<'_, T> {
 ///     .insert_var("y", Value::Number(5.0));
 /// let module = "x + y";
 /// let module = F32Grammar::parse_statements(InputSpan::new(module)).unwrap();
-/// let mut module = interpreter.compile(&module).unwrap();
+/// let mut module = interpreter.compile("test", &module).unwrap();
 /// assert_eq!(module.run().unwrap(), Value::Number(8.0));
 ///
 /// let mut imports = module.imports().to_owned();

--- a/eval/src/executable.rs
+++ b/eval/src/executable.rs
@@ -2,7 +2,7 @@
 
 use core::ops;
 
-use crate::{Backtrace, ErrorWithBacktrace, Number, Value};
+use crate::{Backtrace, ErrorWithBacktrace, ModuleId, Number, Value};
 use arithmetic_parser::{Grammar, LvalueLen, MaybeSpanned, StripCode};
 
 mod command;
@@ -122,6 +122,11 @@ impl<'a, T: Grammar> ExecutableModule<'a, T> {
             inner,
             imports: ModuleImports { inner: imports },
         }
+    }
+
+    /// Gets the identifier of this module.
+    pub fn id(&self) -> &dyn ModuleId {
+        self.inner.id()
     }
 
     /// Sets the value of an imported variable.
@@ -287,7 +292,7 @@ impl<'a, T: Grammar> ops::IndexMut<&str> for ModuleImports<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compiler::Compiler;
+    use crate::{compiler::Compiler, WildcardId};
 
     use arithmetic_parser::{grammars::F32Grammar, GrammarExt, InputSpan};
 
@@ -298,7 +303,7 @@ mod tests {
 
         let block = "y = x + 2 * (x + 1) + 1; y";
         let block = F32Grammar::parse_statements(InputSpan::new(block)).unwrap();
-        let module = Compiler::compile_module(&env, &block, false).unwrap();
+        let module = Compiler::compile_module(WildcardId, &env, &block, false).unwrap();
 
         let mut module_copy = module.clone();
         module_copy.set_import("x", Value::Number(10.0));
@@ -316,7 +321,7 @@ mod tests {
 
         let block = "x + y";
         let block = F32Grammar::parse_statements(InputSpan::new(block)).unwrap();
-        let module = Compiler::compile_module(&env, &block, false).unwrap();
+        let module = Compiler::compile_module(WildcardId, &env, &block, false).unwrap();
 
         let mut imports = module.imports().to_owned();
         assert!(imports.is_compatible(&module));
@@ -337,7 +342,7 @@ mod tests {
 
         let block = "x + y";
         let block = F32Grammar::parse_statements(InputSpan::new(block)).unwrap();
-        let module = Compiler::compile_module(&env, &block, false).unwrap();
+        let module = Compiler::compile_module(WildcardId, &env, &block, false).unwrap();
 
         let mut other_env = Env::new();
         other_env.push_var("y", Value::<F32Grammar>::Number(1.0));

--- a/eval/src/executable/command.rs
+++ b/eval/src/executable/command.rs
@@ -54,6 +54,8 @@ pub(crate) enum CompiledExpr<'a, T: Grammar> {
     DefineFunction {
         ptr: usize,
         captures: Vec<SpannedAtom<'a, T>>,
+        // Original capture names.
+        capture_names: Vec<String>,
     },
 }
 
@@ -89,9 +91,14 @@ impl<T: Grammar> Clone for CompiledExpr<'_, T> {
                 args: args.clone(),
             },
 
-            Self::DefineFunction { ptr, captures } => Self::DefineFunction {
+            Self::DefineFunction {
+                ptr,
+                captures,
+                capture_names,
+            } => Self::DefineFunction {
                 ptr: *ptr,
                 captures: captures.clone(),
+                capture_names: capture_names.clone(),
             },
         }
     }
@@ -131,9 +138,14 @@ impl<T: Grammar> StripCode for CompiledExpr<'_, T> {
                 args: args.iter().map(StripCode::strip_code).collect(),
             },
 
-            Self::DefineFunction { ptr, captures } => CompiledExpr::DefineFunction {
+            Self::DefineFunction {
+                ptr,
+                captures,
+                capture_names,
+            } => CompiledExpr::DefineFunction {
                 ptr: *ptr,
                 captures: captures.iter().map(StripCode::strip_code).collect(),
+                capture_names: capture_names.clone(),
             },
         }
     }

--- a/eval/src/executable/env.rs
+++ b/eval/src/executable/env.rs
@@ -399,18 +399,19 @@ where
                 }
             }
 
-            CompiledExpr::DefineFunction { ptr, captures } => {
+            CompiledExpr::DefineFunction {
+                ptr,
+                captures,
+                capture_names,
+            } => {
                 let fn_executable = executable.child_fns[*ptr].clone();
                 let captured_values = captures
                     .iter()
                     .map(|capture| self.resolve_atom(&capture.extra))
                     .collect();
-                let capture_names = captures
-                    .iter()
-                    .map(|capture| capture.code_or_location("var"))
-                    .collect();
 
-                let function = InterpretedFn::new(fn_executable, captured_values, capture_names);
+                let function =
+                    InterpretedFn::new(fn_executable, captured_values, capture_names.to_owned());
                 Ok(Value::interpreted_fn(function))
             }
         }

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -723,7 +723,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Interpreter;
+    use crate::{Interpreter, WildcardId};
 
     use arithmetic_parser::{grammars::F32Grammar, GrammarExt, InputSpan};
     use assert_matches::assert_matches;
@@ -860,7 +860,7 @@ mod tests {
         assert_eq!(ret, Value::Bool(true));
 
         let module_block = F32Grammar::parse_statements(InputSpan::new("xs.reverse()")).unwrap();
-        let mut module = interpreter.compile(&module_block).unwrap();
+        let mut module = interpreter.compile(WildcardId, &module_block).unwrap();
 
         for &(input, expected) in SAMPLES {
             let input = input.iter().copied().map(Value::Number).collect();

--- a/eval/src/fns.rs
+++ b/eval/src/fns.rs
@@ -109,9 +109,9 @@ fn extract_fn<'a, T: Grammar>(
 /// let mut interpreter = Interpreter::new();
 /// interpreter.insert_native_fn("assert", fns::Assert);
 /// let err = interpreter.evaluate(&block).unwrap_err();
-/// assert_eq!(*err.main_span().fragment(), "assert(3^2 == 10)");
+/// assert_eq!(*err.source().main_span().code().fragment(), "assert(3^2 == 10)");
 /// assert_matches!(
-///     err.source(),
+///     err.source().kind(),
 ///     EvalError::NativeCall(ref msg) if msg == "Assertion failed"
 /// );
 /// ```

--- a/eval/src/fns/wrapper.rs
+++ b/eval/src/fns/wrapper.rs
@@ -587,15 +587,13 @@ pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 /// [`IntoEvalResult`]: fns/trait.IntoEvalResult.html
 /// [`Value`]: enum.Value.html
 /// [`Function`]: enum.Function.html
-/// [`EvalResult`]: type.EvalResult.html
+/// [`EvalResult`]: error/type.EvalResult.html
 ///
 /// # Examples
 ///
 /// ```
 /// # use arithmetic_parser::{grammars::F32Grammar, Grammar, GrammarExt, InputSpan};
-/// # use arithmetic_eval::{
-/// #     wrap_fn, fns::FnWrapper, CallContext, Function, Interpreter, Value,
-/// # };
+/// # use arithmetic_eval::{wrap_fn, fns::FnWrapper, CallContext, Function, Interpreter, Value};
 /// fn is_function<G: Grammar>(value: Value<'_, G>) -> bool {
 ///     value.is_function()
 /// }
@@ -613,9 +611,7 @@ pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 ///
 /// ```
 /// # use arithmetic_parser::{grammars::F32Grammar, Grammar, GrammarExt, InputSpan};
-/// # use arithmetic_eval::{
-/// #     wrap_fn, fns::FnWrapper, CallContext, Function, Interpreter, Value,
-/// # };
+/// # use arithmetic_eval::{wrap_fn, fns::FnWrapper, CallContext, Function, Interpreter, Value};
 /// // Note that both `Value`s have the same lifetime due to elision.
 /// fn take_if<G: Grammar>(value: Value<'_, G>, condition: bool) -> Value<'_, G> {
 ///     if condition { value } else { Value::void() }

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -113,7 +113,7 @@ pub use self::{
         EvalResult, RepeatedAssignmentContext, SpannedEvalError, TupleLenMismatchContext,
     },
     executable::{ExecutableModule, ModuleImports},
-    module_id::{ModuleId, WildcardId},
+    module_id::{IndexedId, ModuleId, WildcardId},
     values::{CallContext, Function, InterpretedFn, NativeFn, SpannedValue, Value, ValueType},
 };
 

--- a/eval/src/module_id.rs
+++ b/eval/src/module_id.rs
@@ -1,0 +1,37 @@
+//! Module ID.
+
+use core::{any::Any, fmt};
+
+/// FIXME
+pub trait ModuleId: Any + fmt::Display + Send + Sync {
+    /// FIXME
+    fn clone_boxed(&self) -> Box<dyn ModuleId>;
+}
+
+impl fmt::Debug for dyn ModuleId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "ModuleId({})", self)
+    }
+}
+
+impl ModuleId for &'static str {
+    fn clone_boxed(&self) -> Box<dyn ModuleId> {
+        Box::new(*self)
+    }
+}
+
+/// FIXME
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WildcardId;
+
+impl ModuleId for WildcardId {
+    fn clone_boxed(&self) -> Box<dyn ModuleId> {
+        Box::new(*self)
+    }
+}
+
+impl fmt::Display for WildcardId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("*")
+    }
+}

--- a/eval/src/module_id.rs
+++ b/eval/src/module_id.rs
@@ -5,14 +5,36 @@ use core::{
     fmt,
 };
 
-/// FIXME
+/// Identifier of an `ExecutableModule`. This is usually a "small" type, such as an integer
+/// or a string.
+///
+/// The ID is provided when [compiling] or [evaluating] a module. It is displayed in error messages
+/// (using `Display::fmt`). `ModuleId` is also associated with some types (e.g., [`InterpretedFn`]
+/// and [`CodeInModule`]), which allows to obtain module info. This can be particularly useful
+/// for outputting rich error information.
+///
+/// A `ModuleId` can be downcast to a specific type, similarly to [`Any`].
+///
+/// [compiling]: struct.Interpreter.html#method.compile
+/// [evaluating]: struct.Interpreter.html#method.evaluate_named
+/// [`InterpretedFn`]: struct.InterpretedFn.html
+/// [`CodeInModule`]: struct.CodeInModule.html
+/// [`Any`]: https://doc.rust-lang.org/std/any/trait.Any.html
 pub trait ModuleId: Any + fmt::Display + Send + Sync {
-    /// FIXME
+    /// Clones this module ID and boxes the result. It is expected that the output will have
+    /// the same specific type as the original module ID. This operation is generally expected
+    /// to be quite cheap.
     fn clone_boxed(&self) -> Box<dyn ModuleId>;
 }
 
 impl dyn ModuleId {
-    /// FIXME
+    /// Returns `true` if the boxed type is the same as `T`.
+    ///
+    /// This method is effectively a carbon copy of [`<dyn Any>::is`]. Such a copy is necessary
+    /// because `&dyn ModuleId` cannot be converted to `&dyn Any`, despite `ModuleId` having `Any`
+    /// as a super-trait.
+    ///
+    /// [`<dyn Any>::is`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.is
     #[inline]
     pub fn is<T: Any>(&self) -> bool {
         let t = TypeId::of::<T>();
@@ -20,10 +42,16 @@ impl dyn ModuleId {
         t == concrete
     }
 
-    /// FIXME
+    /// Returns a reference to the boxed value if it is of type `T`, or `None` if it isn't.
+    ///
+    /// This method is effectively a carbon copy of [`<dyn Any>::downcast_ref`]. Such a copy
+    /// is necessary because `&dyn ModuleId` cannot be converted to `&dyn Any`, despite `ModuleId`
+    /// having `Any` as a super-trait.
+    ///
+    /// [`<dyn Any>::downcast_ref`]: https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_ref
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        // Same code as for `<dyn Any>::downcast_ref()`.
         if self.is::<T>() {
+            // SAFETY: Same code as for `<dyn Any>::downcast_ref()`.
             unsafe { Some(&*(self as *const dyn ModuleId as *const T)) }
         } else {
             None
@@ -43,8 +71,11 @@ impl ModuleId for &'static str {
     }
 }
 
-/// FIXME
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Module identifier that has a single possible value, which is displayed as `*`.
+///
+/// This type is a `ModuleId`-compatible replacement of `()`; `()` does not implement `Display`
+/// and thus cannot implement `ModuleId` directly.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WildcardId;
 
 impl ModuleId for WildcardId {
@@ -56,5 +87,41 @@ impl ModuleId for WildcardId {
 impl fmt::Display for WildcardId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("*")
+    }
+}
+
+/// Indexed module ID containing a prefix part (e.g., `snippet`).
+///
+/// The ID is `Display`ed as `{prefix} #{index + 1}`:
+///
+/// ```
+/// # use arithmetic_eval::IndexedId;
+/// let module_id = IndexedId::new("snippet", 4);
+/// assert_eq!(module_id.to_string(), "snippet #5");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IndexedId {
+    /// Prefix that can identify the nature of the module, such as `snippet`.
+    pub prefix: &'static str,
+    /// 0-based index of the module.
+    pub index: usize,
+}
+
+impl IndexedId {
+    /// Creates a new ID instance.
+    pub const fn new(prefix: &'static str, index: usize) -> Self {
+        Self { prefix, index }
+    }
+}
+
+impl fmt::Display for IndexedId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} #{}", self.prefix, self.index + 1)
+    }
+}
+
+impl ModuleId for IndexedId {
+    fn clone_boxed(&self) -> Box<dyn ModuleId> {
+        Box::new(*self)
     }
 }

--- a/eval/src/module_id.rs
+++ b/eval/src/module_id.rs
@@ -18,7 +18,7 @@ use core::{
 /// [compiling]: struct.Interpreter.html#method.compile
 /// [evaluating]: struct.Interpreter.html#method.evaluate_named_block
 /// [`InterpretedFn`]: struct.InterpretedFn.html
-/// [`CodeInModule`]: struct.CodeInModule.html
+/// [`CodeInModule`]: error/struct.CodeInModule.html
 /// [`Any`]: https://doc.rust-lang.org/std/any/trait.Any.html
 pub trait ModuleId: Any + fmt::Display + Send + Sync {
     /// Clones this module ID and boxes the result. It is expected that the output will have

--- a/eval/src/module_id.rs
+++ b/eval/src/module_id.rs
@@ -1,11 +1,34 @@
 //! Module ID.
 
-use core::{any::Any, fmt};
+use core::{
+    any::{Any, TypeId},
+    fmt,
+};
 
 /// FIXME
 pub trait ModuleId: Any + fmt::Display + Send + Sync {
     /// FIXME
     fn clone_boxed(&self) -> Box<dyn ModuleId>;
+}
+
+impl dyn ModuleId {
+    /// FIXME
+    #[inline]
+    pub fn is<T: Any>(&self) -> bool {
+        let t = TypeId::of::<T>();
+        let concrete = self.type_id();
+        t == concrete
+    }
+
+    /// FIXME
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        // Same code as for `<dyn Any>::downcast_ref()`.
+        if self.is::<T>() {
+            unsafe { Some(&*(self as *const dyn ModuleId as *const T)) }
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Debug for dyn ModuleId {

--- a/eval/src/module_id.rs
+++ b/eval/src/module_id.rs
@@ -16,7 +16,7 @@ use core::{
 /// A `ModuleId` can be downcast to a specific type, similarly to [`Any`].
 ///
 /// [compiling]: struct.Interpreter.html#method.compile
-/// [evaluating]: struct.Interpreter.html#method.evaluate_named
+/// [evaluating]: struct.Interpreter.html#method.evaluate_named_block
 /// [`InterpretedFn`]: struct.InterpretedFn.html
 /// [`CodeInModule`]: struct.CodeInModule.html
 /// [`Any`]: https://doc.rust-lang.org/std/any/trait.Any.html

--- a/eval/tests/hof.rs
+++ b/eval/tests/hof.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to define high-order native functions.
 
 use arithmetic_eval::{
-    fns, wrap_fn, wrap_fn_with_context, CallContext, EvalError, EvalResult, Function, Interpreter,
+    fns, wrap_fn, wrap_fn_with_context, CallContext, ErrorKind, EvalResult, Function, Interpreter,
     NativeFn, Number, SpannedValue, Value,
 };
 use arithmetic_parser::{grammars::F32Grammar, Grammar, GrammarExt, InputSpan, StripCode};
@@ -24,7 +24,7 @@ where
         context: &mut CallContext<'_, 'a>,
     ) -> EvalResult<'a, G> {
         if args.len() != 1 {
-            let err = EvalError::native("Should be called with single argument");
+            let err = ErrorKind::native("Should be called with single argument");
             return Err(context.call_site_error(err));
         }
         let mut arg = args.pop().unwrap();
@@ -58,7 +58,7 @@ fn eager_repeat<'a, G: Grammar<Lit = f32>>(
     mut arg: Value<'a, G>,
 ) -> EvalResult<'a, G> {
     if times <= 0.0 {
-        Err(context.call_site_error(EvalError::native("`times` should be positive")))
+        Err(context.call_site_error(ErrorKind::native("`times` should be positive")))
     } else {
         for _ in 0..times as usize {
             arg = function.evaluate(vec![context.apply_call_span(arg)], context)?;

--- a/test-wasm/src/lib.rs
+++ b/test-wasm/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::format;
+use alloc::{format, string::ToString};
 use core::f64;
 
 use arithmetic_eval::{fns, Interpreter, Value};
@@ -83,16 +83,9 @@ pub fn evaluate(program: &str) -> Result<JsValue, JsValue> {
     let mut interpreter = Interpreter::with_prelude();
     initialize_interpreter(&mut interpreter);
 
-    let value = interpreter.evaluate(&statements).map_err(|err| {
-        let main_span = err.main_span();
-        let message = format!(
-            "{}:{}: {}",
-            main_span.location_line(),
-            main_span.get_column(),
-            err.source()
-        );
-        Error::new(&message)
-    })?;
+    let value = interpreter
+        .evaluate(&statements)
+        .map_err(|err| Error::new(&err.to_string()))?;
 
     match value {
         Value::Number(number) => Ok(JsValue::from(number)),


### PR DESCRIPTION
Proof of the concept that owned modules can be used in practice. There are also changes to some eval APIs (such as ones concerning error reporting), some of which are breaking.

closes #27