### PR TITLE
Fix number parsing

### DIFF
--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -28,6 +28,18 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
   - Use `Error` as the main error type instead of a `Spanned<_>` wrapper.
   - Implement `std::error::Error` for `Error`.
 
+### Fixed
+
+- Fix parsing of expressions like `1.abs()` for standard grammars. Previously,
+  the parser consumed the `.` char as a part of the number literal, which led
+  to a parser error. (#33)
+
+- Fix relative priority of unary ops and method calls, so that `-1.abs()`
+  is correctly parsed as `-(1.abs())`, not as `(-1).abs()`. (#33)
+
+- Disallow using literals as function names. Thus, an expression like `1(2, x)`
+  is no longer valid. (#33)
+
 ## 0.2.0-beta.1 - 2020-10-04
 
 ### Added

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -17,6 +17,11 @@ pub enum ErrorKind {
     NonAsciiInput,
     /// Error parsing literal.
     Literal(anyhow::Error),
+    /// Literal is used where a name is expected, e.g., as a function identifier.
+    ///
+    /// An example of input triggering this error is `1(2, x)`; `1` is used as the function
+    /// identifier.
+    LiteralName,
     /// Error parsing type hint.
     Type(anyhow::Error),
     /// Unary or binary operation switched off in the parser features.
@@ -49,6 +54,8 @@ impl fmt::Display for ErrorKind {
         match self {
             Self::NonAsciiInput => formatter.write_str("Non-ASCII inputs are not supported"),
             Self::Literal(e) => write!(formatter, "Invalid literal: {}", e),
+            Self::LiteralName => formatter.write_str("Literal used in place of an identifier"),
+
             Self::Type(e) => write!(formatter, "Invalid type hint: {}", e),
 
             Self::UnsupportedOp(op) => write!(

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -11,7 +11,6 @@
 //!     grammars::F32Grammar,
 //!     GrammarExt, NomResult, Statement, Expr, FnDefinition, LvalueLen,
 //! };
-//! use nom::number::complete::float;
 //!
 //! const PROGRAM: &str = r#"
 //!     ## This is a comment.
@@ -498,21 +497,21 @@ pub enum Op {
 impl fmt::Display for Op {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Op::Unary(inner) => fmt::Display::fmt(inner, formatter),
-            Op::Binary(inner) => fmt::Display::fmt(inner, formatter),
+            Self::Unary(inner) => fmt::Display::fmt(inner, formatter),
+            Self::Binary(inner) => fmt::Display::fmt(inner, formatter),
         }
     }
 }
 
 impl From<UnaryOp> for Op {
     fn from(value: UnaryOp) -> Self {
-        Op::Unary(value)
+        Self::Unary(value)
     }
 }
 
 impl From<BinaryOp> for Op {
     fn from(value: BinaryOp) -> Self {
-        Op::Binary(value)
+        Self::Binary(value)
     }
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -133,10 +133,7 @@ impl Context {
 /// Arithmetic expression with an abstract types for type hints and literals.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum Expr<'a, T>
-where
-    T: Grammar,
-{
+pub enum Expr<'a, T: Grammar> {
     /// Variable use, e.g., `x`.
     Variable,
 

--- a/parser/src/parser/tests.rs
+++ b/parser/src/parser/tests.rs
@@ -6,7 +6,7 @@ use nom::{
 };
 
 use super::*;
-use crate::{alloc::String, Features, Op};
+use crate::{alloc::String, grammars::F32Grammar, Features, Op};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum LiteralType {
@@ -1580,4 +1580,15 @@ fn order_comparisons_when_switched_off() {
         *spanned_err.kind(),
         ErrorKind::UnsupportedOp(Op::Binary(BinaryOp::Ge))
     );
+}
+
+#[test]
+fn function_call_with_literal_as_fn_name() {
+    let input = InputSpan::new("1(2, 3);");
+    let err = expr::<FieldGrammar, Complete>(input).unwrap_err();
+    let spanned_err = match err {
+        NomErr::Failure(spanned) => spanned,
+        _ => panic!("Unexpected error: {}", err),
+    };
+    assert_matches!(spanned_err.kind(), ErrorKind::LiteralName);
 }

--- a/parser/src/traits.rs
+++ b/parser/src/traits.rs
@@ -57,10 +57,70 @@ impl Default for Features {
 }
 
 /// Unites all necessary parsers to form a complete grammar definition.
+///
+/// The two extension points for a `Grammar` are *literals* and *type annotations*. Each of them
+/// have a corresponding associated type and a parser method ([`Lit`] and [`parse_literal`]
+/// for literals; [`Type`] and [`parse_type`] for annotations).
+///
+/// A `Grammar` also defines a set of supported [`Features`]. This allows to customize which
+/// constructs are parsed.
+///
+/// [`Lit`]: #associatedtype.Lit
+/// [`parse_literal`]: #tymethod.parse_literal
+/// [`Type`]: #associatedtype.Type
+/// [`parse_type`]: #tymethod.parse_type
+/// [`Features`]: struct.Features.html
+///
+/// # Examples
+///
+/// ```
+/// use arithmetic_parser::{Features, Grammar, GrammarExt, InputSpan, NomResult};
+///
+/// /// Grammar that parses `u64` numbers and has a single type annotation, `Num`.
+/// #[derive(Debug)]
+/// struct IntegerGrammar;
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// struct Num;
+///
+/// impl Grammar for IntegerGrammar {
+///     type Lit = u64;
+///     type Type = Num;
+///     const FEATURES: Features = Features::all();
+///
+///     // We use the `nom` crate to construct necessary parsers.
+///     fn parse_literal(input: InputSpan<'_>) -> NomResult<'_, Self::Lit> {
+///         use nom::{character::complete::digit1, combinator::map_res};
+///         map_res(digit1, |s: InputSpan<'_>| s.fragment().parse())(input)
+///     }
+///
+///     fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+///         use nom::{bytes::complete::tag, combinator::map};
+///         map(tag("Num"), |_| Num)(input)
+///     }
+/// }
+///
+/// // Here's how a grammar can be used.
+/// # fn main() -> anyhow::Result<()> {
+/// let program = r#"
+///     x = 1 + 2 * 3 + sin(a^3 / b^2);
+///     some_function = |a, b: Num| (a + b, a - b);
+///     other_function = |x| {
+///         r = min(rand(), 0);
+///         r * x
+///     };
+///     (y, z: Num) = some_function({ x = x - 1; x }, x);
+///     other_function(y - z)
+/// "#;
+/// let parsed = IntegerGrammar::parse_statements(program)?;
+/// println!("{:#?}", parsed);
+/// # Ok(())
+/// # }
+/// ```
 pub trait Grammar: 'static {
     /// Type of the literal used in the grammar.
     type Lit: Clone + fmt::Debug;
-    /// Type of the type declaration used in the grammar.
+    /// Type of the type annotation used in the grammar.
     type Type: Clone + fmt::Debug;
 
     /// Features supported by this grammar.
@@ -68,9 +128,29 @@ pub trait Grammar: 'static {
 
     /// Attempts to parse a literal.
     ///
+    /// Literals should follow these rules:
+    ///
+    /// - A literal must be distinguished from other constructs, in particular,
+    ///   variable identifiers.
+    /// - If a literal may end with `.` and methods are enabled in [`FEATURES`], care should be
+    ///   taken for cases when `.` is a part of a call, rather than a part of a literal.
+    ///   For example, a parser for real-valued literals should interpret `1.abs()`
+    ///   as a call of the `abs` method on receiver `1`, rather than `1.` followed by
+    ///   ineligible `abs()`.
+    ///
+    /// If a literal may start with `-` or `!` (in general, unary ops), these ops will be
+    /// consumed as a part of the literal, rather than `Expr::Unary`, *unless* the literal
+    /// is followed by an eligible higher-priority operation (i.e., a method call) *and*
+    /// the literal without a preceding unary op is still eligible. That is, if `-1` and `1`
+    /// are both valid literals, then `-1.abs()` will be parsed as negation applied to `1.abs()`.
+    /// On the other hand, if `!foo!` is a valid literal, but `foo!` isn't, `!foo!.bar()` will
+    /// be parsed as method `bar()` called on `!foo!`.
+    ///
     /// # Return value
     ///
     /// The output should follow `nom` conventions on errors / failures.
+    ///
+    /// [`FEATURES`]: #associatedconstant.FEATURES
     fn parse_literal(input: InputSpan<'_>) -> NomResult<'_, Self::Lit>;
 
     /// Attempts to parse a type hint.


### PR DESCRIPTION
This PR fixes parsing of method calls with a number receiver and also disallows numbers as function names.

closes #30