### PR TITLE
Typing: Introduce `any` types

### DIFF
--- a/typing/src/arith/constraints.rs
+++ b/typing/src/arith/constraints.rs
@@ -141,8 +141,7 @@ impl<Prim: LinearType> TypeConstraints<Prim> for LinConstraints {
             ValueType::Var(_) => Ok(()),
 
             ValueType::Prim(lit) if lit.is_linear() => Ok(()),
-
-            ValueType::Some => unreachable!(),
+            ValueType::Some => Ok(()),
 
             ValueType::Function(_) | ValueType::Prim(_) => Err(TypeErrorKind::failed_constraint(
                 ty.to_owned(),

--- a/typing/src/arith/constraints.rs
+++ b/typing/src/arith/constraints.rs
@@ -140,7 +140,7 @@ impl<Prim: LinearType> TypeConstraints<Prim> for LinConstraints {
             ValueType::Some => unreachable!(),
 
             // `Var`s are taken care of previously. `Any` satisfies any constraints.
-            ValueType::Any | ValueType::Var(_) => Ok(()),
+            ValueType::Any(_) | ValueType::Var(_) => Ok(()),
 
             ValueType::Prim(lit) if lit.is_linear() => Ok(()),
 

--- a/typing/src/arith/constraints.rs
+++ b/typing/src/arith/constraints.rs
@@ -137,11 +137,12 @@ impl<Prim: LinearType> TypeConstraints<Prim> for LinConstraints {
         };
 
         match resolved_ty {
-            // `Var`s are taken care of previously.
-            ValueType::Var(_) => Ok(()),
+            ValueType::Some => unreachable!(),
+
+            // `Var`s are taken care of previously. `Any` satisfies any constraints.
+            ValueType::Any | ValueType::Var(_) => Ok(()),
 
             ValueType::Prim(lit) if lit.is_linear() => Ok(()),
-            ValueType::Some => Ok(()),
 
             ValueType::Function(_) | ValueType::Prim(_) => Err(TypeErrorKind::failed_constraint(
                 ty.to_owned(),

--- a/typing/src/ast/conversion.rs
+++ b/typing/src/ast/conversion.rs
@@ -255,7 +255,7 @@ impl<'a, Prim: PrimitiveType> ValueTypeAst<'a, Prim> {
     ) -> Result<ValueType<Prim>, ConversionError<&'a str>> {
         Ok(match self {
             Self::Some => ValueType::Some,
-            Self::Any => ValueType::Any,
+            Self::Any(constraints) => ValueType::Any(constraints.computed.clone()),
             Self::Prim(prim) => ValueType::Prim(prim.to_owned()),
 
             Self::Param(ident) => {

--- a/typing/src/ast/conversion.rs
+++ b/typing/src/ast/conversion.rs
@@ -254,7 +254,8 @@ impl<'a, Prim: PrimitiveType> ValueTypeAst<'a, Prim> {
         state: Option<&mut ConversionState<'a>>,
     ) -> Result<ValueType<Prim>, ConversionError<&'a str>> {
         Ok(match self {
-            Self::Any => ValueType::Some,
+            Self::Some => ValueType::Some,
+            Self::Any => ValueType::Any,
             Self::Prim(prim) => ValueType::Prim(prim.to_owned()),
 
             Self::Param(ident) => {

--- a/typing/src/ast/mod.rs
+++ b/typing/src/ast/mod.rs
@@ -10,7 +10,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_until, take_while, take_while1, take_while_m_n},
     character::complete::char as tag_char,
-    combinator::{cut, map, opt, peek, recognize},
+    combinator::{cut, map, not, opt, peek, recognize},
     multi::{many0, separated_list0, separated_list1},
     sequence::{delimited, preceded, terminated, tuple},
     Err as NomErr,
@@ -19,7 +19,7 @@ use nom::{
 use std::str::FromStr;
 
 use crate::{Num, PrimitiveType};
-use arithmetic_parser::{ErrorKind as ParserErrorKind, InputSpan, NomResult};
+use arithmetic_parser::{ErrorKind as ParseErrorKind, InputSpan, NomResult};
 
 mod conversion;
 #[cfg(test)]
@@ -62,7 +62,7 @@ pub enum ValueTypeAst<'a, Prim: PrimitiveType = Num> {
     /// in type annotations in Rust.
     Some,
     /// Any type (`any`).
-    Any,
+    Any(TypeConstraintsAst<'a, Prim>),
     /// Primitive types.
     Prim(Prim),
     /// Ticked identifier, e.g., `'T`.
@@ -173,13 +173,22 @@ pub struct ConstraintsAst<'a, Prim: PrimitiveType> {
 }
 
 /// Bounds that can be placed on a type variable.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct TypeConstraintsAst<'a, Prim: PrimitiveType> {
     /// Spans corresponding to constraints, e.g. `Foo` and `Bar` in `Foo + Bar`.
     pub terms: Vec<InputSpan<'a>>,
     /// Computed constraint.
     pub computed: Prim::Constraints,
+}
+
+impl<Prim: PrimitiveType> Default for TypeConstraintsAst<'_, Prim> {
+    fn default() -> Self {
+        Self {
+            terms: vec![],
+            computed: Prim::Constraints::default(),
+        }
+    }
 }
 
 /// Whitespace and comments.
@@ -319,7 +328,7 @@ fn type_bounds<Prim: PrimitiveType>(
             let input_str = *input.fragment();
             let partial = Prim::Constraints::from_str(input_str).map_err(|_| {
                 let err = anyhow::anyhow!("Cannot parse type constraint");
-                ParserErrorKind::Type(err).with_span(&input.into())
+                ParseErrorKind::Type(err).with_span(&input.into())
             })?;
             acc |= &partial;
             Ok(acc)
@@ -410,18 +419,32 @@ fn fn_definition_with_constraints<Prim: PrimitiveType>(
     )(input)
 }
 
+fn any_type<Prim: PrimitiveType>(
+    input: InputSpan<'_>,
+) -> NomResult<'_, TypeConstraintsAst<'_, Prim>> {
+    let not_ident_char = peek(not(take_while_m_n(1, 1, |c: char| {
+        c.is_ascii_alphanumeric() || c == '_'
+    })));
+    map(
+        preceded(
+            terminated(tag("any"), not_ident_char),
+            opt(preceded(ws, type_bounds)),
+        ),
+        Option::unwrap_or_default,
+    )(input)
+}
+
 fn free_ident<Prim: PrimitiveType>(input: InputSpan<'_>) -> NomResult<'_, ValueTypeAst<'_, Prim>> {
     let (rest, ident) = ident(input)?;
 
     let output = match *ident.fragment() {
         "_" => ValueTypeAst::Some,
-        "any" => ValueTypeAst::Any,
         ident_str => {
             if let Ok(res) = ident_str.parse::<Prim>() {
                 ValueTypeAst::Prim(res)
             } else {
                 let err = anyhow::anyhow!("Unknown type name: {}", ident_str);
-                let err = ParserErrorKind::Type(err).with_span(&ident.into());
+                let err = ParseErrorKind::Type(err).with_span(&ident.into());
                 return Err(NomErr::Failure(err));
             }
         }
@@ -442,6 +465,7 @@ fn type_definition<Prim: PrimitiveType>(
         }),
         map(type_param_ident, ValueTypeAst::Param),
         map(slice_definition, ValueTypeAst::Slice),
+        map(any_type, ValueTypeAst::Any),
         free_ident,
     ))(input)
 }

--- a/typing/src/ast/tests.rs
+++ b/typing/src/ast/tests.rs
@@ -70,9 +70,9 @@ fn simple_tuple() {
         tuple.start,
         vec![
             ValueTypeAst::Prim(Num::Num),
-            ValueTypeAst::Any,
+            ValueTypeAst::Some,
             ValueTypeAst::Prim(Num::Bool),
-            ValueTypeAst::Any,
+            ValueTypeAst::Some,
         ]
     );
 }
@@ -90,7 +90,7 @@ fn complex_tuples() {
     const SAMPLES: &[TupleSample] = &[
         TupleSample {
             input: "(Num, _, ...[Bool; _])",
-            start: &[ValueTypeAst::Prim(Num::Num), ValueTypeAst::Any],
+            start: &[ValueTypeAst::Prim(Num::Num), ValueTypeAst::Some],
             middle_element: ValueTypeAst::Prim(Num::Bool),
             end: &[],
         },
@@ -102,7 +102,7 @@ fn complex_tuples() {
         },
         TupleSample {
             input: "(_, ...[Bool; _], Num)",
-            start: &[ValueTypeAst::Any],
+            start: &[ValueTypeAst::Some],
             middle_element: ValueTypeAst::Prim(Num::Bool),
             end: &[ValueTypeAst::Prim(Num::Num)],
         },
@@ -338,4 +338,13 @@ fn multiple_fns_with_constraints() {
         ValueTypeAst::Param(id) if *id.fragment() == "T"
     );
     assert_matches!(second_fn.return_type, ValueTypeAst::Tuple(t) if t.start.is_empty());
+}
+
+#[test]
+fn any_type() {
+    let input = InputSpan::new("any");
+    let (rest, ty) = type_definition::<Num>(input).unwrap();
+
+    assert!(rest.fragment().is_empty());
+    assert_matches!(ty, ValueTypeAst::Any);
 }

--- a/typing/src/env/tests.rs
+++ b/typing/src/env/tests.rs
@@ -25,8 +25,7 @@ pub fn assert_incompatible_types<Prim: PrimitiveType>(
 
 fn hash_fn_type() -> FnType<Num> {
     FnType {
-        // TODO: use `ValueType::Any` instead of `ValueType::Some`
-        args: Slice::new(ValueType::param(0), UnknownLen::param(0)).into(),
+        args: Slice::new(ValueType::Some, UnknownLen::param(0)).into(),
         return_type: ValueType::NUM,
         params: None,
     }
@@ -34,7 +33,7 @@ fn hash_fn_type() -> FnType<Num> {
 
 #[test]
 fn hash_fn_type_display() {
-    assert_eq!(hash_fn_type().to_string(), "(...['T; N]) -> Num");
+    assert_eq!(hash_fn_type().to_string(), "(...[_; N]) -> Num");
 }
 
 /// `zip` function signature:
@@ -109,7 +108,7 @@ fn function_definition() {
     type_env.process_statements(&block).unwrap();
     assert_eq!(
         type_env.get("sign").unwrap().to_string(),
-        "(Num, Num) -> (Num, Num)"
+        "(Num, 'T) -> (Num, Num)"
     );
 }
 
@@ -136,7 +135,7 @@ fn non_linear_types_in_function() {
     );
     assert_eq!(
         type_env.get("add_hashes").unwrap().to_string(),
-        "('T, 'T) -> Num"
+        "('T, 'U) -> Num"
     );
 }
 
@@ -960,4 +959,83 @@ fn constraint_passed_to_wrapping_fn() {
         .unwrap();
 
     assert_eq!(double_fn.to_string(), "for<'T: Lin> ('T) -> 'T");
+}
+
+#[test]
+fn some_can_be_unified_with_anything() {
+    let code = r#"
+        any == 5 && any == (2, 3);
+        any(2, (3, 5)) == any(7);
+        any.map(|x| x + 3) == (2, 4, 5); // could be valid
+        any.map(|x| x + 3) == (1 == 2); // cannot be valid; the output is a slice of numbers
+    "#;
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    let err = type_env
+        .insert("any", ValueType::Some)
+        .insert("map", Prelude::Map)
+        .process_statements(&block)
+        .unwrap_err();
+
+    let lhs_slice = match err.kind() {
+        TypeErrorKind::TypeMismatch(ValueType::Tuple(tuple), bool) if *bool == ValueType::BOOL => {
+            tuple.as_slice().unwrap()
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    };
+    assert_eq!(*lhs_slice.element(), ValueType::NUM);
+}
+
+#[test]
+fn some_can_be_copied_and_unified_with_anything() {
+    let code = r#"
+        any = some;
+        any == 5 && any == (2, 3);
+        any(2, (3, 5)) == any(7);
+    "#;
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    type_env
+        .insert("some", ValueType::Some)
+        .process_statements(&block)
+        .unwrap();
+}
+
+#[test]
+fn some_can_be_destructured_and_unified_with_anything() {
+    let code = r#"
+        (any, ...) = some_tuple;
+        any == 5 && any == (2, 3);
+        any(2, (3, 5)) == any(7);
+    "#;
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    type_env
+        .insert("some_tuple", ValueType::Some.repeat(3))
+        .process_statements(&block)
+        .unwrap();
+}
+
+#[test]
+fn unifying_types_containing_some() {
+    let code = "digest(1, (2, 3), |x| x + 1)";
+    let block = F32Grammar::parse_statements(code).unwrap();
+
+    let digest_type = FnType::builder()
+        .with_arg(ValueType::NUM)
+        .with_varargs(ValueType::Some, UnknownLen::param(0))
+        .returning(ValueType::NUM);
+    let mut type_env = TypeEnvironment::new();
+    let output = type_env
+        .insert("digest", digest_type)
+        .process_statements(&block)
+        .unwrap();
+
+    assert_eq!(output, ValueType::NUM);
+
+    let bogus_code = "digest(2 == 3, 5)";
+    let bogus_block = F32Grammar::parse_statements(bogus_code).unwrap();
+    let err = type_env.process_statements(&bogus_block).unwrap_err();
+
+    assert_incompatible_types(err.kind(), &ValueType::NUM, &ValueType::BOOL);
 }

--- a/typing/src/env/tests.rs
+++ b/typing/src/env/tests.rs
@@ -25,7 +25,7 @@ pub fn assert_incompatible_types<Prim: PrimitiveType>(
 
 fn hash_fn_type() -> FnType<Num> {
     FnType {
-        args: Slice::new(ValueType::Some, UnknownLen::param(0)).into(),
+        args: Slice::new(ValueType::Any, UnknownLen::param(0)).into(),
         return_type: ValueType::NUM,
         params: None,
     }
@@ -33,7 +33,7 @@ fn hash_fn_type() -> FnType<Num> {
 
 #[test]
 fn hash_fn_type_display() {
-    assert_eq!(hash_fn_type().to_string(), "(...[_; N]) -> Num");
+    assert_eq!(hash_fn_type().to_string(), "(...[any; N]) -> Num");
 }
 
 /// `zip` function signature:
@@ -711,10 +711,10 @@ fn function_passed_as_arg_invalid_arg_type() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err();
 
-    assert_incompatible_types(
-        &err.kind(),
-        &ValueType::NUM,
-        &ValueType::Tuple(vec![ValueType::Some; 2].into()),
+    assert_matches!(
+        err.kind(),
+        TypeErrorKind::TypeMismatch(ValueType::Tuple(t), rhs)
+            if t.len() == TupleLen::from(2) && *rhs == ValueType::NUM
     );
 }
 
@@ -962,17 +962,19 @@ fn constraint_passed_to_wrapping_fn() {
 }
 
 #[test]
-fn some_can_be_unified_with_anything() {
+fn any_can_be_unified_with_anything() {
     let code = r#"
         any == 5 && any == (2, 3);
         any(2, (3, 5)) == any(7);
+        any + 2;
+        any * (3, 5);
         any.map(|x| x + 3) == (2, 4, 5); // could be valid
         any.map(|x| x + 3) == (1 == 2); // cannot be valid; the output is a slice of numbers
     "#;
     let block = F32Grammar::parse_statements(code).unwrap();
     let mut type_env = TypeEnvironment::new();
     let err = type_env
-        .insert("any", ValueType::Some)
+        .insert("any", ValueType::Any)
         .insert("map", Prelude::Map)
         .process_statements(&block)
         .unwrap_err();
@@ -987,43 +989,63 @@ fn some_can_be_unified_with_anything() {
 }
 
 #[test]
-fn some_can_be_copied_and_unified_with_anything() {
+fn any_propagates_via_fn_params() {
     let code = r#"
-        any = some;
+        identity = |x| x;
+        identity(any) == 5 && identity(any) == (2, 3, 1 == 1);
+        val = identity(any);
+        val == 5 && val == (7, 8) // works: `val: any`
+    "#;
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    type_env
+        .insert("any", ValueType::Any)
+        .process_statements(&block)
+        .unwrap();
+
+    assert_eq!(type_env["val"], ValueType::Any);
+}
+
+#[test]
+fn any_can_be_copied_and_unified_with_anything() {
+    let code = r#"
+        any = any_other;
         any == 5 && any == (2, 3);
+        any + 3;
         any(2, (3, 5)) == any(7);
     "#;
     let block = F32Grammar::parse_statements(code).unwrap();
     let mut type_env = TypeEnvironment::new();
     type_env
-        .insert("some", ValueType::Some)
+        .insert("any_other", ValueType::Any)
         .process_statements(&block)
         .unwrap();
 }
 
 #[test]
-fn some_can_be_destructured_and_unified_with_anything() {
+fn any_can_be_destructured_and_unified_with_anything() {
     let code = r#"
         (any, ...) = some_tuple;
         any == 5 && any == (2, 3);
+        any + 3;
         any(2, (3, 5)) == any(7);
     "#;
     let block = F32Grammar::parse_statements(code).unwrap();
     let mut type_env = TypeEnvironment::new();
     type_env
-        .insert("some_tuple", ValueType::Some.repeat(3))
+        .insert("some_tuple", ValueType::Any.repeat(3))
         .process_statements(&block)
         .unwrap();
 }
 
 #[test]
-fn unifying_types_containing_some() {
+fn unifying_types_containing_any() {
     let code = "digest(1, (2, 3), |x| x + 1)";
     let block = F32Grammar::parse_statements(code).unwrap();
 
     let digest_type = FnType::builder()
         .with_arg(ValueType::NUM)
-        .with_varargs(ValueType::Some, UnknownLen::param(0))
+        .with_varargs(ValueType::Any, UnknownLen::param(0))
         .returning(ValueType::NUM);
     let mut type_env = TypeEnvironment::new();
     let output = type_env

--- a/typing/src/lib.rs
+++ b/typing/src/lib.rs
@@ -6,6 +6,9 @@
 //! Type inference is *partially* compatible with the interpreter from [`arithmetic-eval`];
 //! if the inference algorithm succeeds on a certain expression / statement / block,
 //! it will execute successfully, but not all successfully executing items pass type inference.
+//! (An exception here is [`ValueType::Any`], which is specifically designed to circumvent
+//! the type system limitations. If `Any` is used too liberally, it can result in code passing
+//! type checks, but failing during execution.)
 //!
 //! # Type system
 //!

--- a/typing/src/substitutions/mod.rs
+++ b/typing/src/substitutions/mod.rs
@@ -167,8 +167,6 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
         lhs: &ValueType<Prim>,
         rhs: &ValueType<Prim>,
     ) -> Result<(), TypeErrorKind<Prim>> {
-        use self::ValueType::{Function, Tuple, Var};
-
         let resolved_lhs = self.fast_resolve(lhs).to_owned();
         let resolved_rhs = self.fast_resolve(rhs).to_owned();
 
@@ -176,24 +174,35 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
         // accuracy of error reporting, and for some cases of type inference (e.g.,
         // instantiation of parametric functions).
         match (&resolved_lhs, &resolved_rhs) {
-            (ty, other_ty) if ty == other_ty => {
-                // We already know that types are equal.
-                Ok(())
-            }
-
-            (Var(var), ty) | (ty, Var(var)) => {
+            // Variables should be assigned *before* the equality check to account for
+            // `var <- some` assignment.
+            (ValueType::Var(var), ty) => {
                 if var.is_free() {
-                    self.unify_var(var.index(), ty)
+                    self.unify_var(var.index(), ty, true)
+                } else {
+                    Err(TypeErrorKind::UnresolvedParam)
+                }
+            }
+            (ty, ValueType::Var(var)) => {
+                if var.is_free() {
+                    self.unify_var(var.index(), ty, false)
                 } else {
                     Err(TypeErrorKind::UnresolvedParam)
                 }
             }
 
-            (Tuple(lhs_tuple), Tuple(rhs_tuple)) => {
+            (ty, other_ty) if ty == other_ty => {
+                // We already know that types are equal.
+                Ok(())
+            }
+
+            (ValueType::Tuple(lhs_tuple), ValueType::Tuple(rhs_tuple)) => {
                 self.unify_tuples(lhs_tuple, rhs_tuple, TupleLenMismatchContext::Assignment)
             }
 
-            (Function(lhs_fn), Function(rhs_fn)) => self.unify_fn_types(lhs_fn, rhs_fn),
+            (ValueType::Function(lhs_fn), ValueType::Function(rhs_fn)) => {
+                self.unify_fn_types(lhs_fn, rhs_fn)
+            }
 
             (ty, other_ty) => {
                 let mut resolver = self.resolver();
@@ -442,7 +451,20 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
         &mut self,
         var_idx: usize,
         ty: &ValueType<Prim>,
+        is_lhs: bool,
     ) -> Result<(), TypeErrorKind<Prim>> {
+        if let ValueType::Var(var) = ty {
+            if !var.is_free() {
+                return Err(TypeErrorKind::UnresolvedParam);
+            } else if var.index() == var_idx {
+                return Ok(());
+            }
+        }
+        if matches!(ty, ValueType::Some) && !is_lhs {
+            // `Some` <- `Var` assignment; we shouldn't create a type var equation.
+            return Ok(());
+        }
+
         // variables should be resolved in `unify`.
         debug_assert!(!self.eqs.contains_key(&var_idx));
         debug_assert!(if let ValueType::Var(var) = ty {

--- a/typing/src/substitutions/mod.rs
+++ b/typing/src/substitutions/mod.rs
@@ -174,8 +174,8 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
         // accuracy of error reporting, and for some cases of type inference (e.g.,
         // instantiation of parametric functions).
         match (&resolved_lhs, &resolved_rhs) {
-            // Variables should be assigned *before* the equality check to account for
-            // `var <- some` assignment.
+            // Variables should be assigned *before* the equality check and dealing with `Any`
+            // to account for `Var <- Any` assignment.
             (ValueType::Var(var), ty) => {
                 if var.is_free() {
                     self.unify_var(var.index(), ty, true)
@@ -191,6 +191,7 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
                 }
             }
 
+            // This takes care of `Any` types because they are equal to anything.
             (ty, other_ty) if ty == other_ty => {
                 // We already know that types are equal.
                 Ok(())
@@ -460,8 +461,8 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
                 return Ok(());
             }
         }
-        if matches!(ty, ValueType::Some) && !is_lhs {
-            // `Some` <- `Var` assignment; we shouldn't create a type var equation.
+        if matches!(ty, ValueType::Any) && !is_lhs {
+            // `Any` <- `Var` assignment; we shouldn't create a type var equation.
             return Ok(());
         }
 

--- a/typing/src/substitutions/tests.rs
+++ b/typing/src/substitutions/tests.rs
@@ -222,3 +222,25 @@ fn unifying_complex_tuples() {
         assert_eq!(substitutions.eqs[&i], ValueType::NUM);
     }
 }
+
+#[test]
+fn some_can_be_unified_with_anything() {
+    let mut substitutions = Substitutions::<Num>::default();
+    substitutions.eqs.insert(0, ValueType::Some);
+
+    let rhs_samples = &[
+        ValueType::NUM,
+        ValueType::BOOL,
+        (ValueType::BOOL, ValueType::NUM).into(),
+        ValueType::NUM.repeat(3).into(),
+        ValueType::NUM.repeat(UnknownLen::free_var(0)).into(),
+        FnType::new(
+            vec![ValueType::BOOL, ValueType::NUM].into(),
+            ValueType::void(),
+        )
+        .into(),
+    ];
+    for rhs in rhs_samples {
+        substitutions.unify(&ValueType::free_var(0), rhs).unwrap();
+    }
+}

--- a/typing/src/substitutions/tests.rs
+++ b/typing/src/substitutions/tests.rs
@@ -224,9 +224,9 @@ fn unifying_complex_tuples() {
 }
 
 #[test]
-fn some_can_be_unified_with_anything() {
+fn any_can_be_unified_with_anything() {
     let mut substitutions = Substitutions::<Num>::default();
-    substitutions.eqs.insert(0, ValueType::Some);
+    substitutions.eqs.insert(0, ValueType::Any);
 
     let rhs_samples = &[
         ValueType::NUM,
@@ -239,6 +239,7 @@ fn some_can_be_unified_with_anything() {
             ValueType::void(),
         )
         .into(),
+        ValueType::Any,
     ];
     for rhs in rhs_samples {
         substitutions.unify(&ValueType::free_var(0), rhs).unwrap();

--- a/typing/src/substitutions/tests.rs
+++ b/typing/src/substitutions/tests.rs
@@ -226,7 +226,7 @@ fn unifying_complex_tuples() {
 #[test]
 fn any_can_be_unified_with_anything() {
     let mut substitutions = Substitutions::<Num>::default();
-    substitutions.eqs.insert(0, ValueType::Any);
+    substitutions.eqs.insert(0, ValueType::any());
 
     let rhs_samples = &[
         ValueType::NUM,
@@ -239,7 +239,7 @@ fn any_can_be_unified_with_anything() {
             ValueType::void(),
         )
         .into(),
-        ValueType::Any,
+        ValueType::any(),
     ];
     for rhs in rhs_samples {
         substitutions.unify(&ValueType::free_var(0), rhs).unwrap();

--- a/typing/src/types/fn_type.rs
+++ b/typing/src/types/fn_type.rs
@@ -43,9 +43,9 @@ impl<Prim: PrimitiveType> fmt::Display for ParamConstraints<Prim> {
         }
 
         let type_param_count = self.type_params.len();
-        for (&idx, constraints) in &self.type_params {
+        for (i, (idx, constraints)) in self.type_params().enumerate() {
             write!(formatter, "'{}: {}", TypeVar::param_str(idx), constraints)?;
-            if idx + 1 < type_param_count {
+            if i + 1 < type_param_count {
                 formatter.write_str(", ")?;
             }
         }
@@ -57,6 +57,19 @@ impl<Prim: PrimitiveType> fmt::Display for ParamConstraints<Prim> {
 impl<Prim: PrimitiveType> ParamConstraints<Prim> {
     fn is_empty(&self) -> bool {
         self.type_params.is_empty() && self.dyn_lengths.is_empty()
+    }
+
+    // Sort params by ascending index to have a consistent `Display` presentation.
+    #[cfg(test)]
+    fn type_params(&self) -> impl Iterator<Item = (usize, &Prim::Constraints)> + '_ {
+        let mut type_params: Vec<_> = self.type_params.iter().map(|(&idx, c)| (idx, c)).collect();
+        type_params.sort_unstable_by_key(|(idx, _)| *idx);
+        type_params.into_iter()
+    }
+
+    #[cfg(not(test))]
+    fn type_params(&self) -> impl Iterator<Item = (usize, &Prim::Constraints)> + '_ {
+        self.type_params.iter().map(|(&idx, c)| (idx, c))
     }
 }
 

--- a/typing/src/visit.rs
+++ b/typing/src/visit.rs
@@ -96,7 +96,7 @@ where
     V: Visit<'ast, Prim> + ?Sized,
 {
     match ty {
-        ValueType::Some | ValueType::Any => { /* Do nothing. */ }
+        ValueType::Some | ValueType::Any(_) => { /* Do nothing. */ }
         ValueType::Var(var) => visitor.visit_var(*var),
         ValueType::Prim(primitive) => visitor.visit_primitive(primitive),
         ValueType::Tuple(tuple) => visitor.visit_tuple(tuple),
@@ -201,7 +201,7 @@ where
     V: VisitMut<Prim> + ?Sized,
 {
     match ty {
-        ValueType::Some | ValueType::Any | ValueType::Var(_) | ValueType::Prim(_) => {}
+        ValueType::Some | ValueType::Any(_) | ValueType::Var(_) | ValueType::Prim(_) => {}
         ValueType::Tuple(tuple) => visitor.visit_tuple_mut(tuple),
         ValueType::Function(function) => visitor.visit_function_mut(function.as_mut()),
     }

--- a/typing/src/visit.rs
+++ b/typing/src/visit.rs
@@ -96,7 +96,7 @@ where
     V: Visit<'ast, Prim> + ?Sized,
 {
     match ty {
-        ValueType::Some => { /* Do nothing. */ }
+        ValueType::Some | ValueType::Any => { /* Do nothing. */ }
         ValueType::Var(var) => visitor.visit_var(*var),
         ValueType::Prim(primitive) => visitor.visit_primitive(primitive),
         ValueType::Tuple(tuple) => visitor.visit_tuple(tuple),
@@ -201,7 +201,7 @@ where
     V: VisitMut<Prim> + ?Sized,
 {
     match ty {
-        ValueType::Some | ValueType::Var(_) | ValueType::Prim(_) => {}
+        ValueType::Some | ValueType::Any | ValueType::Var(_) | ValueType::Prim(_) => {}
         ValueType::Tuple(tuple) => visitor.visit_tuple_mut(tuple),
         ValueType::Function(function) => visitor.visit_function_mut(function.as_mut()),
     }


### PR DESCRIPTION
Work similarly to `any` in TypeScript.

closes #69