### PR TITLE
Field access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,6 +159,7 @@ jobs:
         run: node test-wasm/test.js
 
   document:
+    if: github.event_name == 'push'
     needs:
       - build
       - build-msrv
@@ -169,11 +170,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache cargo bins
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-document-bin
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
@@ -186,10 +182,6 @@ jobs:
           toolchain: ${{ env.nightly }}
           profile: minimal
           override: true
-      - name: Install deadlinks
-        run: cargo deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
-        env:
-          DEADLINKS_VERS: 0.4.1
 
       - name: Build docs
         run: |
@@ -201,12 +193,8 @@ jobs:
           cargo rustdoc -p arithmetic-eval --all-features -- --cfg docsrs
           cargo rustdoc -p arithmetic-typing --all-features -- --cfg docsrs
 
-      - name: Check dead links
-        run: cargo deadlinks --dir target/doc
-
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.event_name == 'push'
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages

--- a/eval/CHANGELOG.md
+++ b/eval/CHANGELOG.md
@@ -7,7 +7,10 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 ### Added
 
-- Support `Expr::TypeCast` as a no-op.
+- Support `Expr::TypeCast` as a no-op. (#83)
+
+- Support `Expr::FieldAccess` for tuple indexing. Non-numeric fields
+  are not supported yet. (#84)
 
 ## 0.2.0 - 2020-12-05
 

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -93,6 +93,10 @@ impl<'a> CapturesExtractor<'a> {
                 self.eval(name)?;
             }
 
+            Expr::FieldAccess { receiver, .. } => {
+                self.eval(receiver)?;
+            }
+
             Expr::Method {
                 args,
                 receiver,

--- a/eval/src/executable/command.rs
+++ b/eval/src/executable/command.rs
@@ -37,6 +37,10 @@ pub(crate) enum CompiledExpr<'a, T> {
         lhs: SpannedAtom<'a, T>,
         rhs: SpannedAtom<'a, T>,
     },
+    FieldAccess {
+        receiver: SpannedAtom<'a, T>,
+        index: usize, // TODO: generalize to string props
+    },
     Function {
         name: SpannedAtom<'a, T>,
         // Original function name if it is a proper variable name.
@@ -66,6 +70,11 @@ impl<T: Clone> Clone for CompiledExpr<'_, T> {
                 op: *op,
                 lhs: lhs.clone(),
                 rhs: rhs.clone(),
+            },
+
+            Self::FieldAccess { receiver, index } => Self::FieldAccess {
+                receiver: receiver.clone(),
+                index: *index,
             },
 
             Self::Function {
@@ -108,6 +117,11 @@ impl<T: 'static + Clone> StripCode for CompiledExpr<'_, T> {
                 op,
                 lhs: lhs.strip_code(),
                 rhs: rhs.strip_code(),
+            },
+
+            Self::FieldAccess { receiver, index } => CompiledExpr::FieldAccess {
+                receiver: receiver.strip_code(),
+                index,
             },
 
             Self::Function {

--- a/eval/src/executable/registers.rs
+++ b/eval/src/executable/registers.rs
@@ -426,6 +426,22 @@ impl<'a, T: Clone> Registers<'a, T> {
                 }
             }
 
+            CompiledExpr::FieldAccess { receiver, index } => {
+                if let Value::Tuple(mut tuple) = self.resolve_atom(&receiver.extra) {
+                    let len = tuple.len();
+                    if *index >= len {
+                        Err(executable.create_error(
+                            &span,
+                            ErrorKind::IndexOutOfBounds { index: *index, len },
+                        ))
+                    } else {
+                        Ok(tuple.swap_remove(*index))
+                    }
+                } else {
+                    Err(executable.create_error(&span, ErrorKind::CannotIndex))
+                }
+            }
+
             CompiledExpr::Function {
                 name,
                 original_name,

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -54,6 +54,9 @@
 //!
 //! - Order comparisons (`>`, `<`, `>=`, `<=`) are defined for primitive values only and use
 //!   [`OrdArithmetic`].
+//! - Indexing for tuples is performed via [`FieldAccess`] with a numeric field name: `xs.0`.
+//!   Thus, the index is always a "compile-time" constant. An error is raised if the index
+//!   is out of bounds or the receiver is not a tuple.
 //! - No type checks are performed before evaluation.
 //! - Type annotations and type casts are completely ignored.
 //!   This means that the interpreter may execute  code that is incorrect with annotations
@@ -75,6 +78,7 @@
 //! [`arithmetic-parser`]: https://crates.io/crates/arithmetic-parser
 //! [`num-complex`]: https://crates.io/crates/num-complex
 //! [`num-bigint`]: https://crates.io/crates/num-bigint
+//! [`FieldAccess`]: arithmetic_parser::Expr::FieldAccess
 //!
 //! # Examples
 //!

--- a/eval/tests/basics.rs
+++ b/eval/tests/basics.rs
@@ -804,3 +804,18 @@ fn indexed_field_invalid_field_name() {
         ErrorKind::InvalidFieldName(name) if name == "len"
     );
 }
+
+#[test]
+fn overly_large_indexed_field() {
+    let program = "x = (2, 5); x.123456789012345678901234567890";
+    let err = expect_compilation_error(&mut Environment::new(), program);
+
+    assert_eq!(
+        *err.main_span().code().fragment(),
+        "123456789012345678901234567890"
+    );
+    assert_matches!(
+        err.kind(),
+        ErrorKind::InvalidFieldName(name) if name == "123456789012345678901234567890"
+    );
+}

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -10,14 +10,17 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 - Parse type annotations for varargs and tuples with a middle, such as
   `|...xs: T, y| { /* ... */ }` or `(head, ...tail: T)`. (#72)
 
-- Make `with_span` parsing combinator public.
+- Make `with_span` parsing combinator public. (#77)
 
-- Add `Expr::TypeCast` for cast expressions, such as `x as Bool`.
+- Add `Expr::TypeCast` for cast expressions, such as `x as Bool`. (#83)
+
+- Add `Expr::FieldAccess` for field access expressions, such as
+  `point.x` or `xs.0`. (#84)
 
 ### Changed
 
 - Make `Grammar` and `Parse` traits parametric on the lifetime of input.
-  This allows to have type annotations dependent on this lifetime as well.
+  This allows to have type annotations dependent on this lifetime as well. (#77)
 
 ## 0.2.0 - 2020-12-05
 

--- a/typing/src/error/kind.rs
+++ b/typing/src/error/kind.rs
@@ -62,7 +62,8 @@ pub enum ErrorKind<Prim: PrimitiveType> {
     InvalidFieldName(String),
     /// Value cannot be indexed (i.e., not a tuple).
     CannotIndex,
-    /// Unsupported indexing operation. For example, the receiver is a type var.
+    /// Unsupported indexing operation. For example, the receiver type is not known,
+    /// or it is a tuple with an unknown length, and the type of the element cannot be decided.
     UnsupportedIndex,
     /// Index is out of bounds for the indexed tuple.
     IndexOutOfBounds {

--- a/typing/src/error/kind.rs
+++ b/typing/src/error/kind.rs
@@ -58,6 +58,20 @@ pub enum ErrorKind<Prim: PrimitiveType> {
     /// Trying to unify a type with a type containing it.
     RecursiveType(Type<Prim>),
 
+    /// Field name is invalid.
+    InvalidFieldName(String),
+    /// Value cannot be indexed (i.e., not a tuple).
+    CannotIndex,
+    /// Unsupported indexing operation. For example, the receiver is a type var.
+    UnsupportedIndex,
+    /// Index is out of bounds for the indexed tuple.
+    IndexOutOfBounds {
+        /// Index.
+        index: usize,
+        /// Actual tuple length.
+        len: TupleLen,
+    },
+
     /// Mention of a bounded type or length variable in a type supplied
     /// to [`Substitutions::unify()`].
     ///
@@ -134,6 +148,17 @@ impl<Prim: PrimitiveType> fmt::Display for ErrorKind<Prim> {
                 formatter,
                 "Cannot unify type 'T with a type containing it: {}",
                 ty
+            ),
+
+            Self::InvalidFieldName(name) => {
+                write!(formatter, "`{}` is not a valid field name", name)
+            }
+            Self::CannotIndex => formatter.write_str("Value cannot be indexed"),
+            Self::UnsupportedIndex => formatter.write_str("Unsupported indexing operation"),
+            Self::IndexOutOfBounds { index, len } => write!(
+                formatter,
+                "Attempting to get element {} from tuple with length {}",
+                index, len
             ),
 
             Self::UnresolvedParam => {

--- a/typing/src/lib.rs
+++ b/typing/src/lib.rs
@@ -46,7 +46,13 @@
 //! [Hindley–Milner typing rules]: https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Typing_rules
 //! [`TypeArithmetic`]: crate::arith::TypeArithmetic
 //!
-//! # Type casts
+//! # Operations
+//!
+//! ## Tuple indexing
+//!
+//! See [`Tuple` docs](Tuple#indexing) for discussion of indexing expressions, such as `xs.0`.
+//!
+//! ## Type casts
 //!
 //! [A type cast](arithmetic_parser::Expr::TypeCast) is equivalent to introducing a new var
 //! with the specified annotation, assigning to it and returning the new var. That is,

--- a/typing/src/substitutions/mod.rs
+++ b/typing/src/substitutions/mod.rs
@@ -140,7 +140,7 @@ impl<Prim: PrimitiveType> Substitutions<Prim> {
         }
     }
 
-    fn resolve_len(&self, len: TupleLen) -> TupleLen {
+    pub(crate) fn resolve_len(&self, len: TupleLen) -> TupleLen {
         let mut resolved = len;
         while let (Some(UnknownLen::Var(var)), exact) = resolved.components() {
             if !var.is_free() {

--- a/typing/src/types/mod.rs
+++ b/typing/src/types/mod.rs
@@ -14,6 +14,7 @@ mod tuple;
 pub(crate) use self::{
     fn_type::{FnParams, ParamConstraints},
     quantifier::ParamQuantifier,
+    tuple::IndexError,
 };
 pub use self::{
     fn_type::{FnType, FnTypeBuilder, FnWithConstraints},

--- a/typing/src/types/tuple.rs
+++ b/typing/src/types/tuple.rs
@@ -225,6 +225,31 @@ pub enum TupleIndex {
 /// If a tuple only has a middle part ([`Self::as_slice()`] returns `Some(_)`),
 /// it is denoted as the corresponding slice, something like `[T; N]`.
 ///
+/// # Indexing
+///
+/// *Indexing* is accessing tuple elements via an expression like `xs.0`.
+/// Tuple indexing is supported via [`FieldAccess`](arithmetic_parser::Expr::FieldAccess) expr,
+/// where the field name is a decimal `usize` number.
+///
+/// The indexing support for type inference is quite limited.
+/// For it to work, the receiver type must be known to be a tuple, and the index must be such
+/// that the type of the corresponding element is decidable. Otherwise,
+/// an [`UnsupportedIndex`] error will be raised.
+///
+/// | Tuple type | Index | Outcome |
+/// |------------|-------|---------|
+/// | `(Num, Bool)` | 0 | `Num` |
+/// | `(Num, Bool)` | 1 | `Bool` |
+/// | `(Num, Bool)` | 2 | Hard error; the index is out of bounds. |
+/// | `Num` | 0 | Hard error; only tuples can be indexed. |
+/// | `[Num; _]` | 0 | Error; the slice may be empty. |
+/// | `[Num; _ + 1]` | 0 | `Num`; the slice is guaranteed to have 0th element. |
+/// | `(Bool, ...[Num; _])` | 0 | `Bool` |
+/// | `(Bool, ...[Num; _])` | 1 | Error; the slice part may be empty. |
+/// | `(...[Num; _], Bool)` | 0 | Error; cannot decide if the result is `Num` or `Bool`. |
+///
+/// [`UnsupportedIndex`]: crate::error::ErrorKind::UnsupportedIndex
+///
 /// # Examples
 ///
 /// Simple tuples can be created using the [`From`] trait. Complex tuples can be created

--- a/typing/src/types/tuple.rs
+++ b/typing/src/types/tuple.rs
@@ -429,6 +429,34 @@ impl<Prim: PrimitiveType> Tuple<Prim> {
             .chain(&self.end)
     }
 
+    /// Attempts to index into this tuple. `middle_len` specifies the resolved middle length.
+    #[allow(clippy::option_if_let_else)] // hurts readability
+    pub(crate) fn get_element(
+        &self,
+        index: usize,
+        middle_len: TupleLen,
+    ) -> Result<&Type<Prim>, IndexError> {
+        if let Some(element) = self.start.get(index) {
+            Ok(element)
+        } else {
+            self.middle
+                .as_ref()
+                .map_or(Err(IndexError::OutOfBounds), |middle| {
+                    let middle_index = index - self.start.len();
+                    if middle_index < middle_len.exact {
+                        // The element is definitely in the middle.
+                        Ok(middle.element.as_ref())
+                    } else if middle_len.var.is_none() {
+                        // The element is definitely in the end.
+                        let end_index = middle_index - middle_len.exact;
+                        self.end.get(end_index).ok_or(IndexError::OutOfBounds)
+                    } else {
+                        Err(IndexError::NoInfo)
+                    }
+                })
+        }
+    }
+
     /// Returns pairs of elements of this and `other` tuple that should be equal to each other.
     ///
     /// This method is specialized for the case when the length of middles is unknown.
@@ -518,6 +546,15 @@ impl<Prim: PrimitiveType> From<Vec<Type<Prim>>> for Tuple<Prim> {
             end: Vec::new(),
         }
     }
+}
+
+/// Errors that can occur when indexing into a tuple.
+#[derive(Debug)]
+pub(crate) enum IndexError {
+    /// Index is out of bounds.
+    OutOfBounds,
+    /// Not enough info to determine the type.
+    NoInfo,
 }
 
 /// Slice type. Unlike in Rust, slices are a subset of tuples. If `length` is
@@ -620,6 +657,8 @@ impl<Prim: PrimitiveType> From<Slice<Prim>> for Tuple<Prim> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use assert_matches::assert_matches;
 
     #[test]
     fn tuple_length_display() {
@@ -808,6 +847,58 @@ mod tests {
                 // Non-borders in second tuple.
                 (&Type::free_var(0), &Type::free_var(3)),
             ]
+        );
+    }
+
+    #[test]
+    fn tuple_indexing() {
+        // Ordinary tuple.
+        let tuple = Tuple::from(vec![Type::NUM, Type::BOOL]);
+        assert_eq!(*tuple.get_element(0, TupleLen::ZERO).unwrap(), Type::NUM,);
+        assert_eq!(*tuple.get_element(1, TupleLen::ZERO).unwrap(), Type::BOOL,);
+        assert_matches!(
+            tuple.get_element(2, TupleLen::ZERO).unwrap_err(),
+            IndexError::OutOfBounds
+        );
+
+        // Slice.
+        let tuple = Tuple::from(Slice::new(Type::NUM, UnknownLen::param(0)));
+        assert_eq!(*tuple.get_element(0, TupleLen::from(3)).unwrap(), Type::NUM);
+        assert_matches!(
+            tuple.get_element(3, TupleLen::from(3)).unwrap_err(),
+            IndexError::OutOfBounds
+        );
+        assert_matches!(
+            tuple
+                .get_element(0, UnknownLen::free_var(0).into())
+                .unwrap_err(),
+            IndexError::NoInfo
+        );
+        assert_eq!(
+            *tuple.get_element(0, UnknownLen::free_var(0) + 1).unwrap(),
+            Type::NUM
+        );
+
+        // Tuple with all three components.
+        let (tuple, _) = create_test_tuples();
+        assert_eq!(
+            *tuple
+                .get_element(0, UnknownLen::free_var(0).into())
+                .unwrap(),
+            Type::NUM
+        );
+        assert_matches!(
+            tuple
+                .get_element(1, UnknownLen::free_var(0).into())
+                .unwrap_err(),
+            IndexError::NoInfo
+        );
+
+        assert_eq!(*tuple.get_element(1, 2.into()).unwrap(), Type::free_var(0));
+        assert_eq!(*tuple.get_element(3, 2.into()).unwrap(), Type::BOOL);
+        assert_matches!(
+            tuple.get_element(5, 2.into()).unwrap_err(),
+            IndexError::OutOfBounds
         );
     }
 }

--- a/typing/tests/integration/annotations.rs
+++ b/typing/tests/integration/annotations.rs
@@ -438,3 +438,13 @@ fn transmuting_type_via_casts() {
 
     assert_eq!(output.to_string(), "(Num, Num)");
 }
+
+#[test]
+fn indexing_with_annotations() {
+    let code = "|xs: (_, _)| xs.0 + xs.1";
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    let output = type_env.process_statements(&block).unwrap();
+
+    assert_eq!(output.to_string(), "for<'T: Ops> (('T, 'T)) -> 'T");
+}

--- a/typing/tests/integration/errors/annotations.rs
+++ b/typing/tests/integration/errors/annotations.rs
@@ -327,3 +327,15 @@ fn type_cast_error_in_subtype() {
     assert_eq!(err.location(), [tuple_element(1)]);
     assert_eq!(*err.span().fragment(), "|x: Num| x + 3");
 }
+
+#[test]
+fn insufficient_info_when_indexing_tuple() {
+    let code = "xs = (1, 2) as [_]; xs.0";
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let mut type_env = TypeEnvironment::new();
+    let err = type_env.process_statements(&block).unwrap_err().single();
+
+    assert_eq!(*err.span().fragment(), "xs.0");
+    assert_matches!(err.kind(), ErrorKind::UnsupportedIndex);
+    assert_matches!(err.context(), ErrorContext::TupleIndex { ty } if ty.to_string() == "[Num]");
+}

--- a/typing/tests/integration/errors/mod.rs
+++ b/typing/tests/integration/errors/mod.rs
@@ -524,6 +524,22 @@ fn indexing_hard_errors() {
 }
 
 #[test]
+fn overly_large_indexed_field() {
+    let code = "x = (2, 5); x.123456789012345678901234567890";
+    let block = F32Grammar::parse_statements(code).unwrap();
+    let err = TypeEnvironment::new()
+        .process_statements(&block)
+        .unwrap_err()
+        .single();
+
+    assert_eq!(*err.span().fragment(), "123456789012345678901234567890");
+    assert_matches!(
+        err.kind(),
+        ErrorKind::InvalidFieldName(name) if name == "123456789012345678901234567890"
+    );
+}
+
+#[test]
 fn indexing_unsupported_errors() {
     let code = "|xs| xs.0";
     let block = F32Grammar::parse_statements(code).unwrap();

--- a/typing/tests/integration/examples/dsa.script
+++ b/typing/tests/integration/examples/dsa.script
@@ -19,7 +19,7 @@ verify = |(r, s), message, pk| {
 
 // Test!
 (sk, pk) = gen();
-(_, other_pk) = gen();
+other_pk = gen().1;
 
 5.while(|i| i != 0, |i| {
     message = rand_scalar();

--- a/typing/tests/integration/examples/schnorr.script
+++ b/typing/tests/integration/examples/schnorr.script
@@ -19,7 +19,7 @@ verify = |(e, s), message, pk| {
 
 // Test!
 (sk, pk) = gen();
-(_, other_pk) = gen();
+other_pk = gen().1;
 
 5.while(|i| i != 0, |i| {
     message = rand_scalar();


### PR DESCRIPTION
- Supports field access expression in parser. Field name can be either an identifier or an unsigned integer number.
- Supports numeric fields in the eval crate.
- Adds basic support of numeric fields in the typing crate.