### PR TITLE
Support typing of new standard functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "arithmetic-eval",
  "arithmetic-parser",
  "arithmetic-typing",
+ "assert_matches",
  "clap",
  "codespan",
  "codespan-reporting",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,9 @@ arithmetic-parser = { version = "0.3.0", path = "../parser" }
 arithmetic-eval = { version = "0.3.0", path = "../eval", features = ["complex"] }
 arithmetic-typing = { version = "0.3.0", path = "../typing" }
 
+[dev-dependencies]
+assert_matches.workspace = true
+
 [dev-dependencies.term-transcript]
 version = "0.3.0"
 git = "https://github.com/slowli/term-transcript.git"

--- a/cli/src/library.rs
+++ b/cli/src/library.rs
@@ -340,4 +340,53 @@ where
     (env, type_env)
 }
 
-// FIXME: test that returned envs have same variables defined
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use std::collections::HashSet;
+
+    use super::*;
+    use arithmetic_typing::arith::Num;
+
+    #[test]
+    fn environments_are_consistent_for_ints() {
+        let (env, type_env) = create_int_env::<i64>(true);
+        assert_same_values(&env, &type_env);
+    }
+
+    fn assert_same_values<T>(env: &Environment<T>, type_env: &TypeEnvironment) {
+        for (name, value) in env {
+            let value_type = &type_env[name];
+            match value {
+                Value::Prim(_) => assert_matches!(value_type, Type::Prim(Num::Num)),
+                Value::Bool(_) => assert_matches!(value_type, Type::Prim(Num::Bool)),
+                Value::Tuple(_) => assert_matches!(value_type, Type::Tuple(_)),
+                Value::Object(_) => assert_matches!(value_type, Type::Object(_)),
+                Value::Function(_) => assert_matches!(value_type, Type::Function(_)),
+                _ => { /* no check */ }
+            }
+        }
+        let all_names: HashSet<_> = env.iter().map(|(name, _)| name).collect();
+        let all_type_names: HashSet<_> = type_env.iter().map(|(name, _)| name).collect();
+        assert_eq!(all_names, all_type_names);
+    }
+
+    #[test]
+    fn environments_are_consistent_for_modular_arithmetic() {
+        let (env, type_env) = create_modular_env(17);
+        assert_same_values(&env, &type_env);
+    }
+
+    #[test]
+    fn environments_are_consistent_for_floats() {
+        let (env, type_env) = create_float_env::<f64>(1e-5);
+        assert_same_values(&env, &type_env);
+    }
+
+    #[test]
+    fn environments_are_consistent_for_complex_numbers() {
+        let (env, type_env) = create_complex_env::<Complex64>();
+        assert_same_values(&env, &type_env);
+    }
+}

--- a/cli/src/library.rs
+++ b/cli/src/library.rs
@@ -179,7 +179,7 @@ where
         .chain(defs::Assertions::iter())
         .chain(comparison_type_defs())
         .chain(T::STD_LIB.type_defs())
-        .chain(vec![
+        .chain([
             ("rem", binary_fn()),
             ("array", defs::Prelude::array(NumType::Num).into()),
         ])
@@ -196,7 +196,7 @@ pub fn create_modular_env(modulus: u64) -> (Environment<'static, u64>, TypeEnvir
 
     let type_env = defs::Prelude::iter()
         .chain(defs::Assertions::iter())
-        .chain(vec![("MAX_VALUE", Type::NUM)])
+        .chain([("MAX_VALUE", Type::NUM)])
         .collect();
 
     (env, type_env)
@@ -268,9 +268,14 @@ where
         .chain(defs::Assertions::iter())
         .chain(comparison_type_defs())
         .chain(T::STD_LIB.type_defs())
-        .chain(vec![("array", defs::Prelude::array(NumType::Num).into())])
+        .chain([
+            ("array", defs::Prelude::array(NumType::Num).into()),
+            (
+                "assert_close",
+                defs::Assertions::assert_close(NumType::Num).into(),
+            ),
+        ])
         .collect();
-
     (env, type_env)
 }
 
@@ -334,3 +339,5 @@ where
 
     (env, type_env)
 }
+
+// FIXME: test that returned envs have same variables defined

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -222,7 +222,7 @@ impl EvalArgs {
         self,
         (env, type_env): (Environment<'static, T>, TypeEnvironment),
     ) -> io::Result<()> {
-        let type_env = if self.types { Some(type_env) } else { None };
+        let type_env = self.types.then_some(type_env);
         if self.interactive {
             repl(env, type_env, Command::color_choice(self.color))
         } else {

--- a/typing/src/defs.rs
+++ b/typing/src/defs.rs
@@ -72,6 +72,8 @@ pub enum Prelude {
     If,
     /// Type of the `while` function.
     While,
+    /// Type of the `defer` function.
+    Defer,
     /// Type of the `map` function.
     Map,
     /// Type of the `filter` function.
@@ -112,6 +114,16 @@ impl<Prim: WithBoolean> From<Prelude> for Type<Prim> {
                     .with_arg(Type::param(0)) // state
                     .with_arg(condition_fn)
                     .with_arg(iter_fn)
+                    .returning(Type::param(0))
+                    .into()
+            }
+
+            Prelude::Defer => {
+                let fn_arg = Function::builder()
+                    .with_arg(Type::param(0))
+                    .returning(Type::param(0));
+                Function::builder()
+                    .with_arg(fn_arg)
                     .returning(Type::param(0))
                     .into()
             }
@@ -183,7 +195,7 @@ impl<Prim: WithBoolean> From<Prelude> for Type<Prim> {
 }
 
 impl Prelude {
-    const VALUES: &'static [Self] = &[Self::True, Self::False, Self::If, Self::While];
+    const VALUES: &'static [Self] = &[Self::True, Self::False, Self::If, Self::While, Self::Defer];
 
     const ARRAY_FUNCTIONS: &'static [Self] = &[
         Self::Map,
@@ -201,6 +213,7 @@ impl Prelude {
             Self::False => "false",
             Self::If => "if",
             Self::While => "while",
+            Self::Defer => "defer",
             Self::Map => "map",
             Self::Filter => "filter",
             Self::Fold => "fold",
@@ -318,6 +331,7 @@ mod tests {
         ("true", "Bool"),
         ("if", "(Bool, 'T, 'T) -> 'T"),
         ("while", "('T, ('T) -> Bool, ('T) -> 'T) -> 'T"),
+        ("defer", "(('T) -> 'T) -> 'T"),
         ("map", "(['T; N], ('T) -> 'U) -> ['U; N]"),
         ("filter", "(['T], ('T) -> Bool) -> ['T]"),
         ("fold", "(['T], 'U, ('U, 'T) -> 'U) -> 'U"),

--- a/typing/src/defs.rs
+++ b/typing/src/defs.rs
@@ -251,6 +251,8 @@ pub enum Assertions {
     Assert,
     /// Type of the `assert_eq` function.
     AssertEq,
+    /// Type of the `assert_fails` function.
+    AssertFails,
 }
 
 impl<Prim: WithBoolean> From<Assertions> for Type<Prim> {
@@ -265,23 +267,42 @@ impl<Prim: WithBoolean> From<Assertions> for Type<Prim> {
                 .with_arg(Type::param(0))
                 .returning(Type::void())
                 .into(),
+            Assertions::AssertFails => {
+                let checked_fn = Function::builder().returning(Type::param(0));
+                Function::builder()
+                    .with_arg(checked_fn)
+                    .returning(Type::void())
+                    .into()
+            }
         }
     }
 }
 
 impl Assertions {
-    const VALUES: &'static [Self] = &[Self::Assert, Self::AssertEq];
+    const VALUES: &'static [Self] = &[Self::Assert, Self::AssertEq, Self::AssertFails];
 
     fn as_str(self) -> &'static str {
         match self {
             Self::Assert => "assert",
             Self::AssertEq => "assert_eq",
+            Self::AssertFails => "assert_fails",
         }
     }
 
     /// Returns an iterator over all type definitions in `Assertions`.
     pub fn iter<Prim: WithBoolean>() -> impl Iterator<Item = (&'static str, Type<Prim>)> {
         Self::VALUES.iter().map(|&val| (val.as_str(), val.into()))
+    }
+
+    /// Returns the type of the `assert_close` function from the eval crate.
+    ///
+    /// This function is not included into [`Self::iter()`] because in the general case
+    /// we don't know the type of arguments it accepts.
+    pub fn assert_close<T: PrimitiveType>(value: T) -> Function<T> {
+        Function::builder()
+            .with_arg(Type::Prim(value.clone()))
+            .with_arg(Type::Prim(value))
+            .returning(Type::void())
     }
 }
 
@@ -318,7 +339,7 @@ mod tests {
 
         assert_eq!(
             Prelude::iter::<Num>()
-                .filter_map(|(name, _)| if name == "Array" { None } else { Some(name) })
+                .filter_map(|(name, _)| (name != "Array").then_some(name))
                 .collect::<HashSet<_>>(),
             expected_types.keys().copied().collect::<HashSet<_>>()
         );
@@ -328,5 +349,33 @@ mod tests {
     fn string_presentation_of_array_type() {
         let array_fn = Prelude::array(Num::Num);
         assert_eq!(array_fn.to_string(), "(Num, (Num) -> 'T) -> ['T]");
+    }
+
+    const EXPECTED_ASSERT_TYPES: &[(&str, &str)] = &[
+        ("assert", "(Bool) -> ()"),
+        ("assert_eq", "('T, 'T) -> ()"),
+        ("assert_fails", "(() -> 'T) -> ()"),
+    ];
+
+    #[test]
+    fn string_representation_of_assert_types() {
+        let expected_types: HashMap<_, _> = EXPECTED_ASSERT_TYPES.iter().copied().collect();
+
+        for (name, ty) in Assertions::iter::<Num>() {
+            assert_eq!(ty.to_string(), expected_types[name]);
+        }
+
+        assert_eq!(
+            Assertions::iter::<Num>()
+                .map(|(name, _)| name)
+                .collect::<HashSet<_>>(),
+            expected_types.keys().copied().collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn string_representation_of_assert_close() {
+        let assert_close_fn = Assertions::assert_close(Num::Num);
+        assert_eq!(assert_close_fn.to_string(), "(Num, Num) -> ()");
     }
 }

--- a/typing/tests/integration/examples/mod.rs
+++ b/typing/tests/integration/examples/mod.rs
@@ -513,9 +513,5 @@ fn quick_sort() {
         .process_with_arithmetic(&NumArithmetic::with_comparisons(), &code)
         .unwrap();
 
-    assert_eq!(
-        env["quick_sort"].to_string(),
-        "([Num; N], ([Num], any) -> [Num]) -> [Num]"
-    );
-    assert_eq!(env["sort"].to_string(), "([Num; N]) -> [Num]");
+    assert_eq!(env["sort"].to_string(), "([Num]) -> [Num]");
 }

--- a/typing/tests/integration/examples/quick_sort.script
+++ b/typing/tests/integration/examples/quick_sort.script
@@ -1,18 +1,16 @@
 //! Version of the quicksort sample from the eval README
 //! with a couple of necessary type annotations.
 
-quick_sort = |xs, quick_sort: (_, any) -> [Num]| {
-    // `any` is necessary because `quick_sort` is recursive otherwise.
-
-    if(xs as [Num] == (), || () as [Num], || {
-        (pivot, ...rest) = xs as any;
-        lesser_part = rest.filter(|x| x < pivot).quick_sort(quick_sort);
-        greater_part = rest.filter(|x| x >= pivot).quick_sort(quick_sort);
-        lesser_part.push(pivot).merge(greater_part)
-    })()
-};
-
-sort = |xs| xs.quick_sort(quick_sort);
+sort = defer(|quick_sort: (_) -> [Num]| {
+    |xs| {
+        if(xs as [Num] == (), || () as [Num], || {
+            (pivot, ...rest) = xs as any;
+            lesser_part = rest.filter(|x| x < pivot).quick_sort();
+            greater_part = rest.filter(|x| x >= pivot).quick_sort();
+            lesser_part.push(pivot).merge(greater_part)
+        })()
+    }
+});
 
 assert_eq((1, 7, -3, 2, -1, 4, 2).sort(), (-3, -1, 1, 2, 2, 4, 7));
 


### PR DESCRIPTION
## What?

Adds typing of new standard functions (`assert_fails`, `assert_close`, `defer`).

## Why?

Brings the typing crate on par with the eval crate. Fixes CLI operation.