### PR TITLE
Remove lifetime dependency on code in eval crate

### DIFF
--- a/cli/src/library.rs
+++ b/cli/src/library.rs
@@ -47,7 +47,7 @@ pub struct StdLibrary<T: 'static> {
 }
 
 impl<T: ReplLiteral> StdLibrary<T> {
-    fn variables(&self) -> impl Iterator<Item = (&'static str, Value<'static, T>)> {
+    fn variables(&self) -> impl Iterator<Item = (&'static str, Value<T>)> {
         let constants = self
             .constants
             .iter()
@@ -66,7 +66,7 @@ impl<T: ReplLiteral> StdLibrary<T> {
         constants.chain(unary_fns).chain(binary_fns)
     }
 
-    fn num_object(&self) -> Object<'static, T> {
+    fn num_object(&self) -> Object<T> {
         let num_object_entries = self.variables().filter_map(|(name, value)| {
             if value.is_function() {
                 Some((name, value))
@@ -141,7 +141,7 @@ where
     }
 }
 
-pub fn create_int_env<T>(wrapping: bool) -> (Environment<'static, T>, TypeEnvironment)
+pub fn create_int_env<T>(wrapping: bool) -> (Environment<T>, TypeEnvironment)
 where
     T: ReplLiteral + ops::Rem + WrappingNeg + CheckedRem,
     WrappingArithmetic: OrdArithmetic<T>,
@@ -188,7 +188,7 @@ where
     (env, type_env)
 }
 
-pub fn create_modular_env(modulus: u64) -> (Environment<'static, u64>, TypeEnvironment) {
+pub fn create_modular_env(modulus: u64) -> (Environment<u64>, TypeEnvironment) {
     let arith = ModularArithmetic::new(modulus).without_comparisons();
     let mut env = Environment::<u64>::with_arithmetic(arith);
     env.extend(Prelude::iter().chain(Assertions::iter()));
@@ -248,7 +248,7 @@ macro_rules! declare_real_functions {
 declare_real_functions!(f32);
 declare_real_functions!(f64);
 
-pub fn create_float_env<T>(tolerance: T) -> (Environment<'static, T>, TypeEnvironment)
+pub fn create_float_env<T>(tolerance: T) -> (Environment<T>, TypeEnvironment)
 where
     T: ReplLiteral,
     StdArithmetic: OrdArithmetic<T>,
@@ -319,7 +319,7 @@ macro_rules! declare_complex_functions {
 declare_complex_functions!(Complex32, f32);
 declare_complex_functions!(Complex64, f64);
 
-pub fn create_complex_env<T>() -> (Environment<'static, T>, TypeEnvironment)
+pub fn create_complex_env<T>() -> (Environment<T>, TypeEnvironment)
 where
     T: ReplLiteral,
     StdArithmetic: Arithmetic<T>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -220,7 +220,7 @@ impl EvalArgs {
 
     fn run_inner<T: ReplLiteral>(
         self,
-        (env, type_env): (Environment<'static, T>, TypeEnvironment),
+        (env, type_env): (Environment<T>, TypeEnvironment),
     ) -> io::Result<()> {
         let type_env = self.types.then_some(type_env);
         if self.interactive {
@@ -232,7 +232,7 @@ impl EvalArgs {
 
     fn run_command<T: ReplLiteral>(
         self,
-        env: Environment<'static, T>,
+        env: Environment<T>,
         type_env: Option<TypeEnvironment>,
     ) -> io::Result<()> {
         let command = match self.command {

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -21,7 +21,7 @@ fn into_io_error(err: ReadlineError) -> io::Error {
 }
 
 pub fn repl<T: ReplLiteral>(
-    env: Environment<'static, T>,
+    env: Environment<T>,
     type_env: Option<TypeEnvironment>,
     color_choice: ColorChoice,
 ) -> io::Result<()> {

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -23,10 +23,7 @@ use arithmetic_eval::{
     env::{Assertions, Prelude},
     fns, CallContext, Environment, EvalResult, ExecutableModule, NativeFn, SpannedValue, Value,
 };
-use arithmetic_parser::{
-    grammars::{NumGrammar, Parse, Untyped},
-    CodeFragment,
-};
+use arithmetic_parser::grammars::{NumGrammar, Parse, Untyped};
 
 #[global_allocator]
 static ALLOCATOR: Heap = Heap::empty();
@@ -47,29 +44,20 @@ const MINMAX_SCRIPT: &str = r#"
 struct Dbg;
 
 impl NativeFn<i32> for Dbg {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, i32>>,
-        ctx: &mut CallContext<'_, 'a, i32>,
-    ) -> EvalResult<'a, i32> {
+        mut args: Vec<SpannedValue<i32>>,
+        ctx: &mut CallContext<'_, i32>,
+    ) -> EvalResult<i32> {
         ctx.check_args_count(&args, 1)?;
         let arg = args.pop().unwrap();
 
-        match arg.fragment() {
-            CodeFragment::Str(code) => hprintln!(
-                "[{line}:{col}] {code} = {val}",
-                line = arg.location_line(),
-                col = arg.get_column(),
-                code = code,
-                val = arg.extra
-            ),
-            CodeFragment::Stripped(_) => hprintln!(
-                "[{line}:{col}] {val}",
-                line = arg.location_line(),
-                col = arg.get_column(),
-                val = arg.extra
-            ),
-        }
+        hprintln!(
+            "[{line}:{col}] {val}",
+            line = arg.location_line(),
+            col = arg.get_column(),
+            val = arg.extra
+        );
         Ok(arg.extra)
     }
 }

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -23,7 +23,7 @@ extern "C" {
 }
 
 #[allow(clippy::type_complexity)]
-fn initialize_env(env: &mut Environment<'_, f64>) {
+fn initialize_env(env: &mut Environment<f64>) {
     const CONSTANTS: &[(&str, f64)] = &[
         ("E", f64_consts::E),
         ("PI", f64_consts::PI),

--- a/eval/CHANGELOG.md
+++ b/eval/CHANGELOG.md
@@ -40,6 +40,9 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Bump minimum supported Rust version to 1.65 and switch to 2021 Rust edition. (#107, #108, #112)
 
+- Remove the lifetime param in `Value`, `ExecutableModule`, `Error` and other types in the crate
+  by stripping code spans on compilation. (#121)
+
 ### Removed
 
 - Remove `ExecutableModelBuilder::set_imports()` as error-prone. Instead, deferred imports

--- a/eval/examples/cyclic_group.rs
+++ b/eval/examples/cyclic_group.rs
@@ -126,7 +126,7 @@ impl CyclicGroupArithmetic {
     }
 
     /// Sets generic imports for the provided `module`.
-    fn define_imports(&self, env: &mut Environment<'_, GroupLiteral>) {
+    fn define_imports(&self, env: &mut Environment<GroupLiteral>) {
         let generator = GroupLiteral::GroupElement(self.generator.clone());
         let prime_subgroup_order = GroupLiteral::Scalar(self.for_group.modulus().to_owned());
         env.insert("GEN", Value::Prim(generator))
@@ -165,11 +165,11 @@ impl HashToScalar {
 }
 
 impl NativeFn<GroupLiteral> for HashToScalar {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        args: Vec<SpannedValue<'a, GroupLiteral>>,
-        context: &mut CallContext<'_, 'a, GroupLiteral>,
-    ) -> EvalResult<'a, GroupLiteral> {
+        args: Vec<SpannedValue<GroupLiteral>>,
+        context: &mut CallContext<'_, GroupLiteral>,
+    ) -> EvalResult<GroupLiteral> {
         // It is relatively easy to implement hashing for all types, but we're fine
         // with implementing it only for literals (scalars and group elements).
 

--- a/eval/examples/cyclic_group.rs
+++ b/eval/examples/cyclic_group.rs
@@ -184,7 +184,7 @@ impl NativeFn<GroupLiteral> for HashToScalar {
                     let err = ErrorKind::native("Cannot hash value");
                     return Err(context
                         .call_site_error(err)
-                        .with_span(arg, AuxErrorInfo::InvalidArg));
+                        .with_location(arg, AuxErrorInfo::InvalidArg));
                 }
             }
         }

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
     // Naturally, spans in the stripped module do not retain refs to source code,
     // but rather contain info sufficient to be recoverable.
     assert_eq!(
-        err.source().main_span().code().location("call"),
+        err.source().location().in_module().to_string("call"),
         "call at 1:40"
     );
 

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -8,7 +8,7 @@ use arithmetic_eval::{
 };
 use arithmetic_parser::{
     grammars::{F64Grammar, MockTypes, Parse, WithMockedTypes},
-    BinaryOp, StripCode, StripResultExt,
+    BinaryOp, Error as ParseError,
 };
 
 /// We need to process some type annotations, but don't want to depend
@@ -22,25 +22,14 @@ impl MockTypes for MockedTypesList {
 
 type Grammar = WithMockedTypes<F64Grammar, MockedTypesList>;
 
-fn create_module<'a>(
-    module_name: &'static str,
-    program: &'a str,
-) -> anyhow::Result<ExecutableModule<'a, f64>> {
-    let block = Grammar::parse_statements(program).strip_err()?;
-    Ok(ExecutableModule::new(module_name, &block).strip_err()?)
-}
-
-fn create_static_module(
+fn create_module(
     module_name: &'static str,
     program: &str,
-) -> anyhow::Result<ExecutableModule<'static, f64>> {
-    // By default, the module is tied by its lifetime to the `program`. However,
-    // we can break this tie using the `StripCode` trait.
-    create_module(module_name, program).map(StripCode::strip_code)
+) -> anyhow::Result<ExecutableModule<f64>> {
+    let block = Grammar::parse_statements(program).map_err(ParseError::strip_code)?;
+    Ok(ExecutableModule::new(module_name, &block)?)
 }
 
-#[allow(unknown_lints, clippy::redundant_locals)]
-// ^ False positive (explained in the comment near the reassignment)
 fn main() -> anyhow::Result<()> {
     let mut env = Environment::new();
     env.extend(Prelude::iter().chain(Assertions::iter()));
@@ -50,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
     let sum_module = {
         let dynamic_program = String::from("|...vars| fold(vars, 0, |acc, x| acc + x)");
-        create_static_module("sum", &dynamic_program)?
+        create_module("sum", &dynamic_program)?
         // Ensure that the program is indeed dropped by using a separate scope.
     };
 
@@ -78,7 +67,7 @@ fn main() -> anyhow::Result<()> {
     // Naturally, spans in the stripped module do not retain refs to source code,
     // but rather contain info sufficient to be recoverable.
     assert_eq!(
-        err.source().main_span().code().code_or_location("call"),
+        err.source().main_span().code().location("call"),
         "call at 1:40"
     );
 
@@ -86,15 +75,15 @@ fn main() -> anyhow::Result<()> {
     let fold_program = include_str!("rfold.script");
     let fold_program = String::from(fold_program);
     let fold_module = create_module("rfold", &fold_program)?;
-    let rfold_fn = fold_module.with_env(&env).strip_err()?.run().strip_err()?;
+    let rfold_fn = fold_module.with_env(&env)?.run()?;
 
     // Due to lifetime checks, we need to re-assign `env`, since the original one
     // is inferred to have `'static` lifetime.
     let mut env = env;
     env.insert("fold", rfold_fn);
-    let rfold_sum = sum_module.with_env(&env).strip_err()?.run().strip_err()?;
+    let rfold_sum = sum_module.with_env(&env)?.run()?;
     env.insert("sum", rfold_sum);
-    let sum_value = test_module.with_env(&env).strip_err()?.run().strip_err()?;
+    let sum_value = test_module.with_env(&env)?.run()?;
     assert_eq!(sum_value, Value::Prim(-2.0));
 
     Ok(())

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -77,9 +77,6 @@ fn main() -> anyhow::Result<()> {
     let fold_module = create_module("rfold", &fold_program)?;
     let rfold_fn = fold_module.with_env(&env)?.run()?;
 
-    // Due to lifetime checks, we need to re-assign `env`, since the original one
-    // is inferred to have `'static` lifetime.
-    let mut env = env;
     env.insert("fold", rfold_fn);
     let rfold_sum = sum_module.with_env(&env)?.run()?;
     env.insert("sum", rfold_sum);

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -34,7 +34,7 @@ impl<'a> CapturesExtractor<'a> {
     pub fn eval_function<T: Grammar<'a>>(
         &mut self,
         definition: &FnDefinition<'a, T>,
-    ) -> Result<(), Error<'a>> {
+    ) -> Result<(), Error> {
         let mut fn_local_vars = HashMap::new();
         extract_vars(
             self.module_id.as_ref(),
@@ -57,13 +57,13 @@ impl<'a> CapturesExtractor<'a> {
         }
     }
 
-    fn create_error<T>(&self, span: &Spanned<'a, T>, err: ErrorKind) -> Error<'a> {
+    fn create_error<T>(&self, span: &Spanned<'a, T>, err: ErrorKind) -> Error {
         Error::new(self.module_id.as_ref(), span, err)
     }
 
     /// Evaluates an expression with the function validation semantics, i.e., to determine
     /// function captures.
-    fn eval<T: Grammar<'a>>(&mut self, expr: &SpannedExpr<'a, T>) -> Result<(), Error<'a>> {
+    fn eval<T: Grammar<'a>>(&mut self, expr: &SpannedExpr<'a, T>) -> Result<(), Error> {
         match &expr.extra {
             Expr::Variable => {
                 self.eval_local_var(expr);
@@ -152,7 +152,7 @@ impl<'a> CapturesExtractor<'a> {
     fn eval_statement<T: Grammar<'a>>(
         &mut self,
         statement: &SpannedStatement<'a, T>,
-    ) -> Result<(), Error<'a>> {
+    ) -> Result<(), Error> {
         match &statement.extra {
             Statement::Expr(expr) => self.eval(expr),
 
@@ -180,7 +180,7 @@ impl<'a> CapturesExtractor<'a> {
         &mut self,
         block: &Block<'a, T>,
         local_vars: HashMap<&'a str, Spanned<'a>>,
-    ) -> Result<(), Error<'a>> {
+    ) -> Result<(), Error> {
         self.local_vars.push(local_vars);
         for statement in &block.statements {
             self.eval_statement(statement)?;
@@ -192,7 +192,7 @@ impl<'a> CapturesExtractor<'a> {
         Ok(())
     }
 
-    pub fn eval_block<T: Grammar<'a>>(&mut self, block: &Block<'a, T>) -> Result<(), Error<'a>> {
+    pub fn eval_block<T: Grammar<'a>>(&mut self, block: &Block<'a, T>) -> Result<(), Error> {
         self.eval_block_inner(block, HashMap::new())
     }
 }
@@ -202,7 +202,7 @@ fn extract_vars<'a, T>(
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     lvalues: &Destructure<'a, T>,
     context: RepeatedAssignmentContext,
-) -> Result<(), Error<'a>> {
+) -> Result<(), Error> {
     let middle = lvalues
         .middle
         .as_ref()
@@ -220,7 +220,7 @@ fn add_var<'a>(
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     var_span: Spanned<'a>,
     context: RepeatedAssignmentContext,
-) -> Result<(), Error<'a>> {
+) -> Result<(), Error> {
     let var_name = *var_span.fragment();
     if var_name != "_" {
         if let Some(prev_span) = vars.insert(var_name, var_span) {
@@ -237,7 +237,7 @@ pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     lvalues: impl Iterator<Item = &'it SpannedLvalue<'a, T>>,
     context: RepeatedAssignmentContext,
-) -> Result<(), Error<'a>> {
+) -> Result<(), Error> {
     for lvalue in lvalues {
         match &lvalue.extra {
             Lvalue::Variable { .. } => {
@@ -283,7 +283,7 @@ pub(super) enum CompilerExtTarget<'r, 'a, T: Grammar<'a>> {
 }
 
 impl<'a, T: Grammar<'a>> CompilerExtTarget<'_, 'a, T> {
-    pub fn get_undefined_variables(self) -> Result<HashMap<&'a str, Spanned<'a>>, Error<'a>> {
+    pub fn get_undefined_variables(self) -> Result<HashMap<&'a str, Spanned<'a>>, Error> {
         let mut extractor = CapturesExtractor::new(Box::new(WildcardId));
 
         match self {

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -119,7 +119,7 @@ impl<'a> CapturesExtractor<'a> {
                     if let Some(prev_span) = object_fields.insert(field_str, *name) {
                         let err = ErrorKind::RepeatedField;
                         return Err(Error::new(self.module_id.as_ref(), name, err)
-                            .with_span(&prev_span.into(), AuxErrorInfo::PrevAssignment));
+                            .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
                     }
                 }
 
@@ -226,7 +226,7 @@ fn add_var<'a>(
         if let Some(prev_span) = vars.insert(var_name, var_span) {
             let err = ErrorKind::RepeatedAssignment { context };
             return Err(Error::new(module_id, &var_span, err)
-                .with_span(&prev_span.into(), AuxErrorInfo::PrevAssignment));
+                .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
         }
     }
     Ok(())
@@ -255,7 +255,7 @@ pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
                     if let Some(prev_span) = object_fields.insert(field_str, field.field_name) {
                         let err = ErrorKind::RepeatedField;
                         return Err(Error::new(module_id, &field.field_name, err)
-                            .with_span(&prev_span.into(), AuxErrorInfo::PrevAssignment));
+                            .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
                     }
 
                     if let Some(binding) = &field.binding {

--- a/eval/src/compiler/expr.rs
+++ b/eval/src/compiler/expr.rs
@@ -17,9 +17,9 @@ use arithmetic_parser::{
 impl Compiler {
     fn compile_expr<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         expr: &SpannedExpr<'a, T>,
-    ) -> Result<SpannedAtom<'a, T::Lit>, Error<'a>> {
+    ) -> Result<SpannedAtom<T::Lit>, Error> {
         let atom = match &expr.extra {
             Expr::Literal(lit) => Atom::Constant(lit.clone()),
 
@@ -91,10 +91,7 @@ impl Compiler {
         Ok(expr.copy_with_extra(atom).into())
     }
 
-    fn compile_var_access<'a, T, A>(
-        &self,
-        var_span: &Spanned<'a, T>,
-    ) -> Result<Atom<A>, Error<'a>> {
+    fn compile_var_access<T, A>(&self, var_span: &Spanned<'_, T>) -> Result<Atom<A>, Error> {
         let var_name = *var_span.fragment();
         let register = self.vars_to_registers.get(var_name).ok_or_else(|| {
             let err = ErrorKind::Undefined(var_name.to_owned());
@@ -105,12 +102,12 @@ impl Compiler {
 
     fn compile_binary_expr<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         binary_expr: &SpannedExpr<'a, T>,
         op: &Spanned<'a, BinaryOp>,
         lhs: &SpannedExpr<'a, T>,
         rhs: &SpannedExpr<'a, T>,
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let lhs = self.compile_expr(executable, lhs)?;
         let rhs = self.compile_expr(executable, rhs)?;
 
@@ -126,11 +123,11 @@ impl Compiler {
 
     fn compile_fn_call<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
         name: &SpannedExpr<'a, T>,
         args: &[SpannedExpr<'a, T>],
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let original_name = *name.fragment();
         let original_name = if is_valid_variable_name(original_name) {
             Some(original_name.to_owned())
@@ -144,12 +141,12 @@ impl Compiler {
 
     fn compile_fn_call_with_precompiled_name<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
-        name: SpannedAtom<'a, T::Lit>,
+        name: SpannedAtom<T::Lit>,
         original_name: Option<String>,
         args: &[SpannedExpr<'a, T>],
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let args = args
             .iter()
             .map(|arg| self.compile_expr(executable, arg))
@@ -165,11 +162,11 @@ impl Compiler {
 
     fn compile_field_access<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
         name: &Spanned<'a>,
         receiver: &SpannedExpr<'a, T>,
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let name_str = *name.fragment();
         let field = name_str
             .parse::<usize>()
@@ -191,12 +188,12 @@ impl Compiler {
 
     fn compile_method_call<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
         name: &SpannedExpr<'a, T>,
         receiver: &SpannedExpr<'a, T>,
         args: &[SpannedExpr<'a, T>],
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let original_name = if matches!(name.extra, Expr::Variable) {
             Some((*name.fragment()).to_owned())
         } else {
@@ -219,10 +216,10 @@ impl Compiler {
 
     fn compile_block<'r, 'a: 'r, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         block_expr: &SpannedExpr<'a, T>,
         block: &Block<'a, T>,
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let backup_state = self.backup();
         if self.scope_depth == 0 {
             let command = Command::StartInnerScope;
@@ -269,9 +266,9 @@ impl Compiler {
 
     pub(super) fn compile_block_inner<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         block: &Block<'a, T>,
-    ) -> Result<Option<SpannedAtom<'a, T::Lit>>, Error<'a>> {
+    ) -> Result<Option<SpannedAtom<T::Lit>>, Error> {
         for statement in &block.statements {
             self.compile_statement(executable, statement)?;
         }
@@ -286,10 +283,10 @@ impl Compiler {
     #[allow(clippy::option_if_let_else)] // false positive
     fn compile_object<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         object_expr: &SpannedExpr<'a, T>,
         object: &ObjectExpr<'a, T>,
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let fields = object.fields.iter().map(|(name, field_expr)| {
             let name_str = *name.fragment();
             if let Some(field_expr) = field_expr {
@@ -307,10 +304,10 @@ impl Compiler {
 
     fn compile_fn_definition<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         def_expr: &SpannedExpr<'a, T>,
         def: &FnDefinition<'a, T>,
-    ) -> Result<Atom<T::Lit>, Error<'a>> {
+    ) -> Result<Atom<T::Lit>, Error> {
         let module_id = self.module_id.clone_boxed();
 
         let mut extractor = CapturesExtractor::new(module_id);
@@ -344,7 +341,7 @@ impl Compiler {
     fn get_captures<'a, T>(
         &self,
         extractor: CapturesExtractor<'a>,
-    ) -> HashMap<&'a str, SpannedAtom<'a, T>> {
+    ) -> HashMap<&'a str, SpannedAtom<T>> {
         extractor
             .captures
             .into_iter()
@@ -359,8 +356,8 @@ impl Compiler {
     fn compile_function<'a, T: Grammar<'a>>(
         &self,
         def: &FnDefinition<'a, T>,
-        captures: &HashMap<&'a str, SpannedAtom<'a, T::Lit>>,
-    ) -> Result<Executable<'a, T::Lit>, Error<'a>> {
+        captures: &HashMap<&'a str, SpannedAtom<T::Lit>>,
+    ) -> Result<Executable<T::Lit>, Error> {
         // Allocate registers for captures.
         let mut this = Self::new(self.module_id.clone_boxed());
         this.scope_depth = 1; // Disable generating variable annotations.
@@ -390,9 +387,9 @@ impl Compiler {
 
     fn compile_statement<'a, T: Grammar<'a>>(
         &mut self,
-        executable: &mut Executable<'a, T::Lit>,
+        executable: &mut Executable<T::Lit>,
         statement: &SpannedStatement<'a, T>,
-    ) -> Result<Option<SpannedAtom<'a, T::Lit>>, Error<'a>> {
+    ) -> Result<Option<SpannedAtom<T::Lit>>, Error> {
         Ok(match &statement.extra {
             Statement::Expr(expr) => Some(self.compile_expr(executable, expr)?),
 

--- a/eval/src/compiler/mod.rs
+++ b/eval/src/compiler/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     Error, ErrorKind, Value,
 };
 use arithmetic_parser::{
-    grammars::Grammar, BinaryOp, Block, Destructure, FnDefinition, InputSpan, Lvalue, MaybeSpanned,
+    grammars::Grammar, BinaryOp, Block, Destructure, FnDefinition, InputSpan, Location, Lvalue,
     ObjectDestructure, Spanned, SpannedLvalue, UnaryOp,
 };
 
@@ -17,7 +17,7 @@ mod expr;
 
 use self::captures::{CapturesExtractor, CompilerExtTarget};
 
-pub(crate) type ImportSpans = Vec<MaybeSpanned>;
+pub(crate) type ImportLocations = Vec<Location>;
 
 #[derive(Debug)]
 pub(crate) struct Compiler {
@@ -139,7 +139,7 @@ impl Compiler {
     fn extract_captures<'a, T: Grammar<'a>>(
         module_id: Box<dyn ModuleId>,
         block: &Block<'a, T>,
-    ) -> Result<(Registers<T::Lit>, ImportSpans), Error> {
+    ) -> Result<(Registers<T::Lit>, ImportLocations), Error> {
         let mut extractor = CapturesExtractor::new(module_id);
         extractor.eval_block(block)?;
 
@@ -395,7 +395,7 @@ mod tests {
         assert_eq!(registers.register_count(), 1);
         assert!(registers.variables_map().contains_key("x"));
         assert_eq!(import_spans.len(), 1);
-        assert_eq!(import_spans[0], MaybeSpanned::from_str(program, 8..9));
+        assert_eq!(import_spans[0], Location::from_str(program, 8..9));
     }
 
     #[test]

--- a/eval/src/env/variable_map.rs
+++ b/eval/src/env/variable_map.rs
@@ -19,7 +19,7 @@ pub struct Prelude;
 
 impl Prelude {
     /// Creates an iterator over contained values and the corresponding names.
-    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<'static, T>)>
+    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<T>)>
     where
         T: 'static + Clone,
     {
@@ -36,7 +36,7 @@ impl Prelude {
         .chain([("Array", array_object.into())])
     }
 
-    fn array_functions<T>() -> impl Iterator<Item = (&'static str, Value<'static, T>)>
+    fn array_functions<T>() -> impl Iterator<Item = (&'static str, Value<T>)>
     where
         T: 'static + Clone,
     {
@@ -59,7 +59,7 @@ pub struct Assertions;
 
 impl Assertions {
     /// Creates an iterator over contained values and the corresponding names.
-    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<'static, T>)>
+    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<T>)>
     where
         T: 'static + Clone + fmt::Display,
     {
@@ -81,7 +81,7 @@ pub struct Comparisons;
 
 impl Comparisons {
     /// Creates an iterator over contained values and the corresponding names.
-    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<'static, T>)> {
+    pub fn iter<T>() -> impl Iterator<Item = (&'static str, Value<T>)> {
         [
             ("LESS", Value::opaque_ref(Ordering::Less)),
             ("EQUAL", Value::opaque_ref(Ordering::Equal)),

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -416,24 +416,6 @@ impl fmt::Display for AuxErrorInfo {
 }
 
 /// Evaluation error together with one or more relevant code spans.
-///
-/// Use the [`StripCode`] implementation to convert an `Error` to the `'static` lifetime, e.g.,
-/// before boxing it into `Box<dyn std::error::Error>` or `anyhow::Error`.
-/// If the error is wrapped into a [`Result`], you can do this via the `StripResultExt` trait
-/// defined in the `arithmetic-parser` crate:
-///
-/// ```
-/// # use arithmetic_parser::{grammars::{F64Grammar, Parse, Untyped}, StripResultExt};
-/// # use arithmetic_eval::{Error, ExecutableModule};
-/// fn compile_code(code: &str) -> anyhow::Result<ExecutableModule<'_, f64>> {
-///     let block = Untyped::<F64Grammar>::parse_statements(code).strip_err()?;
-///
-///     // Without `strip_err()` call, the code below won't compile:
-///     // `Error<'_>` in general cannot be boxed into `anyhow::Error`,
-///     // only `Error<'static>` can.
-///     Ok(ExecutableModule::new("module", &block).strip_err()?)
-/// }
-/// ```
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,

--- a/eval/src/exec/command.rs
+++ b/eval/src/exec/command.rs
@@ -1,7 +1,7 @@
 //! Executable `Command` and its building blocks.
 
 use crate::alloc::{String, Vec};
-use arithmetic_parser::{BinaryOp, LvalueLen, MaybeSpanned, UnaryOp};
+use arithmetic_parser::{BinaryOp, Location, LvalueLen, UnaryOp};
 
 /// Pointer to a register or constant.
 #[derive(Debug)]
@@ -21,7 +21,7 @@ impl<T: Clone> Clone for Atom<T> {
     }
 }
 
-pub(crate) type SpannedAtom<T> = MaybeSpanned<Atom<T>>;
+pub(crate) type LocatedAtom<T> = Location<Atom<T>>;
 
 #[derive(Debug, Clone)]
 pub(crate) enum FieldName {
@@ -37,26 +37,26 @@ pub(crate) enum CompiledExpr<T> {
     Object(Vec<(String, Atom<T>)>),
     Unary {
         op: UnaryOp,
-        inner: SpannedAtom<T>,
+        inner: LocatedAtom<T>,
     },
     Binary {
         op: BinaryOp,
-        lhs: SpannedAtom<T>,
-        rhs: SpannedAtom<T>,
+        lhs: LocatedAtom<T>,
+        rhs: LocatedAtom<T>,
     },
     FieldAccess {
-        receiver: SpannedAtom<T>,
+        receiver: LocatedAtom<T>,
         field: FieldName,
     },
     FunctionCall {
-        name: SpannedAtom<T>,
+        name: LocatedAtom<T>,
         // Original function name if it is a proper variable name.
         original_name: Option<String>,
-        args: Vec<SpannedAtom<T>>,
+        args: Vec<LocatedAtom<T>>,
     },
     DefineFunction {
         ptr: usize,
-        captures: Vec<SpannedAtom<T>>,
+        captures: Vec<LocatedAtom<T>>,
         // Original capture names.
         capture_names: Vec<String>,
     },
@@ -99,4 +99,4 @@ pub(crate) enum Command<T> {
     TruncateRegisters(usize),
 }
 
-pub(crate) type SpannedCommand<T> = MaybeSpanned<Command<T>>;
+pub(crate) type LocatedCommand<T> = Location<Command<T>>;

--- a/eval/src/exec/command.rs
+++ b/eval/src/exec/command.rs
@@ -1,7 +1,7 @@
 //! Executable `Command` and its building blocks.
 
 use crate::alloc::{String, Vec};
-use arithmetic_parser::{BinaryOp, LvalueLen, MaybeSpanned, StripCode, UnaryOp};
+use arithmetic_parser::{BinaryOp, LvalueLen, MaybeSpanned, UnaryOp};
 
 /// Pointer to a register or constant.
 #[derive(Debug)]
@@ -21,7 +21,7 @@ impl<T: Clone> Clone for Atom<T> {
     }
 }
 
-pub(crate) type SpannedAtom<'a, T> = MaybeSpanned<'a, Atom<T>>;
+pub(crate) type SpannedAtom<T> = MaybeSpanned<Atom<T>>;
 
 #[derive(Debug, Clone)]
 pub(crate) enum FieldName {
@@ -30,143 +30,43 @@ pub(crate) enum FieldName {
 }
 
 /// Atomic operation on registers and/or constants.
-#[derive(Debug)]
-pub(crate) enum CompiledExpr<'a, T> {
+#[derive(Debug, Clone)]
+pub(crate) enum CompiledExpr<T> {
     Atom(Atom<T>),
     Tuple(Vec<Atom<T>>),
     Object(Vec<(String, Atom<T>)>),
     Unary {
         op: UnaryOp,
-        inner: SpannedAtom<'a, T>,
+        inner: SpannedAtom<T>,
     },
     Binary {
         op: BinaryOp,
-        lhs: SpannedAtom<'a, T>,
-        rhs: SpannedAtom<'a, T>,
+        lhs: SpannedAtom<T>,
+        rhs: SpannedAtom<T>,
     },
     FieldAccess {
-        receiver: SpannedAtom<'a, T>,
+        receiver: SpannedAtom<T>,
         field: FieldName,
     },
     FunctionCall {
-        name: SpannedAtom<'a, T>,
+        name: SpannedAtom<T>,
         // Original function name if it is a proper variable name.
         original_name: Option<String>,
-        args: Vec<SpannedAtom<'a, T>>,
+        args: Vec<SpannedAtom<T>>,
     },
     DefineFunction {
         ptr: usize,
-        captures: Vec<SpannedAtom<'a, T>>,
+        captures: Vec<SpannedAtom<T>>,
         // Original capture names.
         capture_names: Vec<String>,
     },
 }
 
-impl<T: Clone> Clone for CompiledExpr<'_, T> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Atom(atom) => Self::Atom(atom.clone()),
-            Self::Tuple(atoms) => Self::Tuple(atoms.clone()),
-            Self::Object(fields) => Self::Object(fields.clone()),
-
-            Self::Unary { op, inner } => Self::Unary {
-                op: *op,
-                inner: inner.clone(),
-            },
-
-            Self::Binary { op, lhs, rhs } => Self::Binary {
-                op: *op,
-                lhs: lhs.clone(),
-                rhs: rhs.clone(),
-            },
-
-            Self::FieldAccess {
-                receiver,
-                field: index,
-            } => Self::FieldAccess {
-                receiver: receiver.clone(),
-                field: index.clone(),
-            },
-
-            Self::FunctionCall {
-                name,
-                original_name,
-                args,
-            } => Self::FunctionCall {
-                name: name.clone(),
-                original_name: original_name.clone(),
-                args: args.clone(),
-            },
-
-            Self::DefineFunction {
-                ptr,
-                captures,
-                capture_names,
-            } => Self::DefineFunction {
-                ptr: *ptr,
-                captures: captures.clone(),
-                capture_names: capture_names.clone(),
-            },
-        }
-    }
-}
-
-impl<T: 'static + Clone> StripCode for CompiledExpr<'_, T> {
-    type Stripped = CompiledExpr<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        match self {
-            Self::Atom(atom) => CompiledExpr::Atom(atom),
-            Self::Tuple(atoms) => CompiledExpr::Tuple(atoms),
-            Self::Object(fields) => CompiledExpr::Object(fields),
-
-            Self::Unary { op, inner } => CompiledExpr::Unary {
-                op,
-                inner: inner.strip_code(),
-            },
-
-            Self::Binary { op, lhs, rhs } => CompiledExpr::Binary {
-                op,
-                lhs: lhs.strip_code(),
-                rhs: rhs.strip_code(),
-            },
-
-            Self::FieldAccess {
-                receiver,
-                field: index,
-            } => CompiledExpr::FieldAccess {
-                receiver: receiver.strip_code(),
-                field: index,
-            },
-
-            Self::FunctionCall {
-                name,
-                original_name,
-                args,
-            } => CompiledExpr::FunctionCall {
-                name: name.strip_code(),
-                original_name,
-                args: args.into_iter().map(StripCode::strip_code).collect(),
-            },
-
-            Self::DefineFunction {
-                ptr,
-                captures,
-                capture_names,
-            } => CompiledExpr::DefineFunction {
-                ptr,
-                captures: captures.into_iter().map(StripCode::strip_code).collect(),
-                capture_names,
-            },
-        }
-    }
-}
-
 /// Commands for a primitive register VM used to execute compiled programs.
-#[derive(Debug)]
-pub(crate) enum Command<'a, T> {
+#[derive(Debug, Clone)]
+pub(crate) enum Command<T> {
     /// Create a new register and push the result of the specified computation there.
-    Push(CompiledExpr<'a, T>),
+    Push(CompiledExpr<T>),
 
     /// Destructure a tuple value. This will push `start_len` starting elements from the tuple,
     /// the middle of the tuple (as a tuple), and `end_len` ending elements from the tuple
@@ -199,81 +99,4 @@ pub(crate) enum Command<'a, T> {
     TruncateRegisters(usize),
 }
 
-impl<T: Clone> Clone for Command<'_, T> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Push(expr) => Self::Push(expr.clone()),
-
-            Self::Destructure {
-                source,
-                start_len,
-                end_len,
-                lvalue_len,
-                unchecked,
-            } => Self::Destructure {
-                source: *source,
-                start_len: *start_len,
-                end_len: *end_len,
-                lvalue_len: *lvalue_len,
-                unchecked: *unchecked,
-            },
-
-            Self::Copy {
-                source,
-                destination,
-            } => Self::Copy {
-                source: *source,
-                destination: *destination,
-            },
-
-            Self::Annotate { register, name } => Self::Annotate {
-                register: *register,
-                name: name.clone(),
-            },
-
-            Self::StartInnerScope => Self::StartInnerScope,
-            Self::EndInnerScope => Self::EndInnerScope,
-            Self::TruncateRegisters(size) => Self::TruncateRegisters(*size),
-        }
-    }
-}
-
-impl<T: 'static + Clone> StripCode for Command<'_, T> {
-    type Stripped = Command<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        match self {
-            Self::Push(expr) => Command::Push(expr.strip_code()),
-
-            Self::Destructure {
-                source,
-                start_len,
-                end_len,
-                lvalue_len,
-                unchecked,
-            } => Command::Destructure {
-                source,
-                start_len,
-                end_len,
-                lvalue_len,
-                unchecked,
-            },
-
-            Self::Copy {
-                source,
-                destination,
-            } => Command::Copy {
-                source,
-                destination,
-            },
-
-            Self::Annotate { register, name } => Command::Annotate { register, name },
-
-            Self::StartInnerScope => Command::StartInnerScope,
-            Self::EndInnerScope => Command::EndInnerScope,
-            Self::TruncateRegisters(size) => Command::TruncateRegisters(size),
-        }
-    }
-}
-
-pub(crate) type SpannedCommand<'a, T> = MaybeSpanned<'a, Command<'a, T>>;
+pub(crate) type SpannedCommand<T> = MaybeSpanned<Command<T>>;

--- a/eval/src/exec/mod.rs
+++ b/eval/src/exec/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     error::{Backtrace, Error, ErrorKind, ErrorWithBacktrace},
     Value,
 };
-use arithmetic_parser::{grammars::Grammar, Block, MaybeSpanned, StripCode};
+use arithmetic_parser::{grammars::Grammar, Block, MaybeSpanned};
 
 mod command;
 mod module_id;
@@ -120,12 +120,12 @@ pub use crate::compiler::CompilerExt;
 /// # }
 /// ```
 #[derive(Debug)]
-pub struct ExecutableModule<'a, T> {
-    inner: Executable<'a, T>,
-    imports: ModuleImports<'a, T>,
+pub struct ExecutableModule<T> {
+    inner: Executable<T>,
+    imports: ModuleImports<T>,
 }
 
-impl<T: Clone> Clone for ExecutableModule<'_, T> {
+impl<T: Clone> Clone for ExecutableModule<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -134,20 +134,9 @@ impl<T: Clone> Clone for ExecutableModule<'_, T> {
     }
 }
 
-impl<T: 'static + Clone> StripCode for ExecutableModule<'_, T> {
-    type Stripped = ExecutableModule<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        ExecutableModule {
-            inner: self.inner.strip_code(),
-            imports: self.imports.strip_code(),
-        }
-    }
-}
-
-impl<'a, T: Clone + fmt::Debug> ExecutableModule<'a, T> {
+impl<T: Clone + fmt::Debug> ExecutableModule<T> {
     /// Creates a new module.
-    pub fn new<G, Id>(id: Id, block: &Block<'a, G>) -> Result<Self, Error<'a>>
+    pub fn new<'a, G, Id>(id: Id, block: &Block<'a, G>) -> Result<Self, Error>
     where
         Id: ModuleId,
         G: Grammar<'a, Lit = T>,
@@ -156,11 +145,11 @@ impl<'a, T: Clone + fmt::Debug> ExecutableModule<'a, T> {
     }
 }
 
-impl<'a, T> ExecutableModule<'a, T> {
+impl<T> ExecutableModule<T> {
     pub(crate) fn from_parts(
-        inner: Executable<'a, T>,
-        imports: Registers<'a, T>,
-        import_spans: ImportSpans<'a>,
+        inner: Executable<T>,
+        imports: Registers<T>,
+        import_spans: ImportSpans,
     ) -> Self {
         Self {
             inner,
@@ -194,8 +183,8 @@ impl<'a, T> ExecutableModule<'a, T> {
     /// Returns an error if the environment does not contain all variables imported by this module.
     pub fn with_env<'s>(
         &'s self,
-        env: &'s Environment<'a, T>,
-    ) -> Result<WithEnvironment<'s, 'a, T>, Error<'a>> {
+        env: &'s Environment<T>,
+    ) -> Result<WithEnvironment<'s, T>, Error> {
         self.check_imports(env)?;
         Ok(WithEnvironment {
             module: self,
@@ -203,7 +192,7 @@ impl<'a, T> ExecutableModule<'a, T> {
         })
     }
 
-    fn check_imports(&self, env: &Environment<'a, T>) -> Result<(), Error<'a>> {
+    fn check_imports(&self, env: &Environment<T>) -> Result<(), Error> {
         for (name, span) in self.imports.spanned_iter() {
             if !env.contains(name) {
                 let err = ErrorKind::Undefined(name.into());
@@ -221,8 +210,8 @@ impl<'a, T> ExecutableModule<'a, T> {
     /// Returns an error if the environment does not contain all variables imported by this module.
     pub fn with_mutable_env<'s>(
         &'s self,
-        env: &'s mut Environment<'a, T>,
-    ) -> Result<WithEnvironment<'s, 'a, T>, Error<'a>> {
+        env: &'s mut Environment<T>,
+    ) -> Result<WithEnvironment<'s, T>, Error> {
         self.check_imports(env)?;
         Ok(WithEnvironment {
             module: self,
@@ -231,12 +220,12 @@ impl<'a, T> ExecutableModule<'a, T> {
     }
 }
 
-impl<'a, T: 'static + Clone> ExecutableModule<'a, T> {
+impl<T: 'static + Clone> ExecutableModule<T> {
     fn run_with_registers(
         &self,
-        registers: &mut Registers<'a, T>,
+        registers: &mut Registers<T>,
         operations: Operations<'_, T>,
-    ) -> Result<Value<'a, T>, ErrorWithBacktrace<'a>> {
+    ) -> Result<Value<T>, ErrorWithBacktrace> {
         let mut backtrace = Backtrace::default();
         registers
             .execute(&self.inner, operations, Some(&mut backtrace))
@@ -261,12 +250,12 @@ impl<T> AsRef<T> for Reference<'_, T> {
 
 /// Container for an [`ExecutableModule`] together with an [`Environment`].
 #[derive(Debug)]
-pub struct WithEnvironment<'env, 'a, T> {
-    module: &'env ExecutableModule<'a, T>,
-    env: Reference<'env, Environment<'a, T>>,
+pub struct WithEnvironment<'env, T> {
+    module: &'env ExecutableModule<T>,
+    env: Reference<'env, Environment<T>>,
 }
 
-impl<'a, T: 'static + Clone> WithEnvironment<'_, 'a, T> {
+impl<T: 'static + Clone> WithEnvironment<'_, T> {
     /// Runs the module in the previously provided [`Environment`].
     ///
     /// If a mutable reference was provided to the environment, the environment is modified
@@ -277,7 +266,7 @@ impl<'a, T: 'static + Clone> WithEnvironment<'_, 'a, T> {
     /// # Errors
     ///
     /// Returns an error if module execution fails.
-    pub fn run(self) -> Result<Value<'a, T>, ErrorWithBacktrace<'a>> {
+    pub fn run(self) -> Result<Value<T>, ErrorWithBacktrace> {
         let mut registers = self.module.imports.inner.clone();
         registers.update_from_env(self.env.as_ref());
         let result = self
@@ -293,25 +282,14 @@ impl<'a, T: 'static + Clone> WithEnvironment<'_, 'a, T> {
 
 /// Imports of an [`ExecutableModule`].
 #[derive(Debug, Clone)]
-struct ModuleImports<'a, T> {
-    inner: Registers<'a, T>,
-    spans: ImportSpans<'a>,
+struct ModuleImports<T> {
+    inner: Registers<T>,
+    spans: ImportSpans,
 }
 
-impl<'a, T> ModuleImports<'a, T> {
-    fn spanned_iter(&self) -> impl Iterator<Item = (&str, &MaybeSpanned<'a>)> + '_ {
+impl<T> ModuleImports<T> {
+    fn spanned_iter(&self) -> impl Iterator<Item = (&str, &MaybeSpanned)> + '_ {
         let iter = self.inner.variables_map().iter();
         iter.map(move |(name, idx)| (name.as_str(), &self.spans[*idx]))
-    }
-}
-
-impl<T: 'static + Clone> StripCode for ModuleImports<'_, T> {
-    type Stripped = ModuleImports<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        ModuleImports {
-            inner: self.inner.strip_code(),
-            spans: self.spans.into_iter().map(StripCode::strip_code).collect(),
-        }
     }
 }

--- a/eval/src/exec/module_id.rs
+++ b/eval/src/exec/module_id.rs
@@ -12,13 +12,13 @@ use crate::alloc::Box;
 ///
 /// The ID is provided when [creating](crate::ExecutableModule::new()) a module. It is displayed
 /// in error messages (using `Display::fmt`). `ModuleId` is also associated with some types
-/// (e.g., [`InterpretedFn`] and [`CodeInModule`]), which allows to obtain module info.
+/// (e.g., [`InterpretedFn`] and [`LocationInModule`]), which allows to obtain module info.
 /// This can be particularly useful for outputting rich error information.
 ///
 /// A `ModuleId` can be downcast to a specific type, similarly to [`Any`].
 ///
 /// [`InterpretedFn`]: crate::InterpretedFn
-/// [`CodeInModule`]: crate::error::CodeInModule
+/// [`LocationInModule`]: crate::error::LocationInModule
 pub trait ModuleId: Any + fmt::Display + Send + Sync {
     /// Clones this module ID and boxes the result. It is expected that the output will have
     /// the same specific type as the original module ID. This operation is generally expected

--- a/eval/src/exec/registers.rs
+++ b/eval/src/exec/registers.rs
@@ -8,19 +8,19 @@ use crate::{
     exec::ModuleId,
     CallContext, Environment, Error, ErrorKind, Function, InterpretedFn, SpannedValue, Value,
 };
-use arithmetic_parser::{BinaryOp, LvalueLen, MaybeSpanned, StripCode, UnaryOp};
+use arithmetic_parser::{BinaryOp, LvalueLen, MaybeSpanned, UnaryOp};
 
 /// Sequence of instructions that can be executed with the `Registers`.
 #[derive(Debug)]
-pub(crate) struct Executable<'a, T> {
-    id: Box<dyn ModuleId>,
-    commands: Vec<SpannedCommand<'a, T>>,
-    child_fns: Vec<Rc<ExecutableFn<'a, T>>>,
+pub(crate) struct Executable<T> {
+    id: Box<dyn ModuleId>, // FIXME: consider using `Rc<_>`?
+    commands: Vec<SpannedCommand<T>>,
+    child_fns: Vec<Rc<ExecutableFn<T>>>,
     // Hint how many registers the executable requires.
     register_capacity: usize,
 }
 
-impl<'a, T: Clone> Clone for Executable<'a, T> {
+impl<T: Clone> Clone for Executable<T> {
     fn clone(&self) -> Self {
         Self {
             id: self.id.clone_boxed(),
@@ -31,28 +31,7 @@ impl<'a, T: Clone> Clone for Executable<'a, T> {
     }
 }
 
-impl<T: 'static + Clone> StripCode for Executable<'_, T> {
-    type Stripped = Executable<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        Executable {
-            id: self.id,
-            commands: self
-                .commands
-                .into_iter()
-                .map(|command| command.map_extra(StripCode::strip_code).strip_code())
-                .collect(),
-            child_fns: self
-                .child_fns
-                .into_iter()
-                .map(|function| Rc::new(function.to_stripped_code()))
-                .collect(),
-            register_capacity: self.register_capacity,
-        }
-    }
-}
-
-impl<'a, T> Executable<'a, T> {
+impl<T> Executable<T> {
     pub fn new(id: Box<dyn ModuleId>) -> Self {
         Self {
             id,
@@ -66,15 +45,15 @@ impl<'a, T> Executable<'a, T> {
         self.id.as_ref()
     }
 
-    fn create_error<U>(&self, span: &MaybeSpanned<'a, U>, err: ErrorKind) -> Error<'a> {
+    fn create_error<U>(&self, span: &MaybeSpanned<U>, err: ErrorKind) -> Error {
         Error::new(self.id.as_ref(), span, err)
     }
 
-    pub fn push_command(&mut self, command: impl Into<SpannedCommand<'a, T>>) {
+    pub fn push_command(&mut self, command: impl Into<SpannedCommand<T>>) {
         self.commands.push(command.into());
     }
 
-    pub fn push_child_fn(&mut self, child_fn: ExecutableFn<'a, T>) -> usize {
+    pub fn push_child_fn(&mut self, child_fn: ExecutableFn<T>) -> usize {
         let fn_ptr = self.child_fns.len();
         self.child_fns.push(Rc::new(child_fn));
         fn_ptr
@@ -97,13 +76,13 @@ impl<'a, T> Executable<'a, T> {
     }
 }
 
-impl<'a, T: 'static + Clone> Executable<'a, T> {
+impl<T: 'static + Clone> Executable<T> {
     pub fn call_function(
         &self,
-        captures: Vec<Value<'a, T>>,
-        args: Vec<Value<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        captures: Vec<Value<T>>,
+        args: Vec<Value<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         let mut registers = captures;
         registers.push(Value::Tuple(args.into()));
         let mut env = Registers {
@@ -117,32 +96,10 @@ impl<'a, T: 'static + Clone> Executable<'a, T> {
 
 /// `Executable` together with function-specific info.
 #[derive(Debug)]
-pub(crate) struct ExecutableFn<'a, T> {
-    pub inner: Executable<'a, T>,
-    pub def_span: MaybeSpanned<'a>,
+pub(crate) struct ExecutableFn<T> {
+    pub inner: Executable<T>,
+    pub def_span: MaybeSpanned,
     pub arg_count: LvalueLen,
-}
-
-impl<T: 'static + Clone> ExecutableFn<'_, T> {
-    pub fn to_stripped_code(&self) -> ExecutableFn<'static, T> {
-        ExecutableFn {
-            inner: self.inner.clone().strip_code(),
-            def_span: self.def_span.strip_code(),
-            arg_count: self.arg_count,
-        }
-    }
-}
-
-impl<T: 'static + Clone> StripCode for ExecutableFn<'_, T> {
-    type Stripped = ExecutableFn<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        ExecutableFn {
-            inner: self.inner.strip_code(),
-            def_span: self.def_span.strip_code(),
-            arg_count: self.arg_count,
-        }
-    }
 }
 
 /// Encompasses all irreducible operations defined externally for `Value`s; for now, these are just
@@ -166,10 +123,10 @@ impl<'r, T> From<&'r dyn OrdArithmetic<T>> for Operations<'r, T> {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct Registers<'a, T> {
+#[derive(Debug, Clone)]
+pub(crate) struct Registers<T> {
     // TODO: restore `SmallVec` wrapped into a covariant wrapper.
-    registers: Vec<Value<'a, T>>,
+    registers: Vec<Value<T>>,
     // Maps variables to registers. Variables are mapped only from the global scope;
     // thus, we don't need to remove them on error in an inner scope.
     // TODO: investigate using stack-hosted small strings for keys.
@@ -179,33 +136,7 @@ pub(crate) struct Registers<'a, T> {
     inner_scope_start: Option<usize>,
 }
 
-impl<T: Clone> Clone for Registers<'_, T> {
-    fn clone(&self) -> Self {
-        Self {
-            registers: self.registers.clone(),
-            vars: self.vars.clone(),
-            inner_scope_start: self.inner_scope_start,
-        }
-    }
-}
-
-impl<T: 'static + Clone> StripCode for Registers<'_, T> {
-    type Stripped = Registers<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        Registers {
-            registers: self
-                .registers
-                .into_iter()
-                .map(StripCode::strip_code)
-                .collect(),
-            vars: self.vars,
-            inner_scope_start: self.inner_scope_start,
-        }
-    }
-}
-
-impl<'a, T> Registers<'a, T> {
+impl<T> Registers<T> {
     pub fn new() -> Self {
         Self {
             registers: vec![],
@@ -214,7 +145,7 @@ impl<'a, T> Registers<'a, T> {
         }
     }
 
-    pub fn variables(&self) -> impl Iterator<Item = (&str, &Value<'a, T>)> + '_ {
+    pub fn variables(&self) -> impl Iterator<Item = (&str, &Value<T>)> + '_ {
         self.vars
             .iter()
             .map(move |(name, register)| (name.as_str(), &self.registers[*register]))
@@ -229,7 +160,7 @@ impl<'a, T> Registers<'a, T> {
     }
 
     /// Allocates a new register with the specified name if the name was not allocated previously.
-    pub fn insert_var(&mut self, name: &str, value: Value<'a, T>) -> bool {
+    pub fn insert_var(&mut self, name: &str, value: Value<T>) -> bool {
         if self.vars.contains_key(name) {
             false
         } else {
@@ -242,9 +173,9 @@ impl<'a, T> Registers<'a, T> {
     }
 }
 
-impl<'a, T: Clone> Registers<'a, T> {
+impl<T: Clone> Registers<T> {
     /// Updates from the specified environment. Updates are performed in place.
-    pub fn update_from_env(&mut self, env: &Environment<'a, T>) {
+    pub fn update_from_env(&mut self, env: &Environment<T>) {
         for (var_name, register) in &self.vars {
             if let Some(value) = env.get(var_name) {
                 self.registers[*register] = value.clone();
@@ -253,7 +184,7 @@ impl<'a, T: Clone> Registers<'a, T> {
     }
 
     /// Updates environment from this instance.
-    pub fn update_env(&self, env: &mut Environment<'a, T>) {
+    pub fn update_env(&self, env: &mut Environment<T>) {
         for (var_name, register) in &self.vars {
             let value = self.registers[*register].clone();
             // ^-- We cannot move `value` from `registers` because multiple names may be pointing
@@ -264,13 +195,13 @@ impl<'a, T: Clone> Registers<'a, T> {
     }
 }
 
-impl<'a, T: 'static + Clone> Registers<'a, T> {
+impl<T: 'static + Clone> Registers<T> {
     pub fn execute(
         &mut self,
-        executable: &Executable<'a, T>,
+        executable: &Executable<T>,
         operations: Operations<'_, T>,
-        backtrace: Option<&mut Backtrace<'a>>,
-    ) -> EvalResult<'a, T> {
+        backtrace: Option<&mut Backtrace>,
+    ) -> EvalResult<T> {
         self.execute_inner(executable, operations, backtrace)
             .map_err(|err| {
                 if let Some(scope_start) = self.inner_scope_start.take() {
@@ -283,10 +214,10 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
     #[allow(clippy::needless_option_as_deref)] // false positive
     fn execute_inner(
         &mut self,
-        executable: &Executable<'a, T>,
+        executable: &Executable<T>,
         operations: Operations<'_, T>,
-        mut backtrace: Option<&mut Backtrace<'a>>,
-    ) -> EvalResult<'a, T> {
+        mut backtrace: Option<&mut Backtrace>,
+    ) -> EvalResult<T> {
         if let Some(additional_capacity) = executable
             .register_capacity
             .checked_sub(self.registers.len())
@@ -369,12 +300,12 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
 
     fn execute_expr(
         &self,
-        span: MaybeSpanned<'a>,
-        expr: &CompiledExpr<'a, T>,
-        executable: &Executable<'a, T>,
+        span: MaybeSpanned,
+        expr: &CompiledExpr<T>,
+        executable: &Executable<T>,
         operations: Operations<'_, T>,
-        backtrace: Option<&mut Backtrace<'a>>,
-    ) -> EvalResult<'a, T> {
+        backtrace: Option<&mut Backtrace>,
+    ) -> EvalResult<T> {
         match expr {
             CompiledExpr::Atom(atom) => Ok(self.resolve_atom(atom)),
 
@@ -464,12 +395,12 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
     fn execute_binary_expr(
         &self,
         module_id: &dyn ModuleId,
-        span: MaybeSpanned<'a>,
+        span: MaybeSpanned,
         op: BinaryOp,
-        lhs: &SpannedAtom<'a, T>,
-        rhs: &SpannedAtom<'a, T>,
+        lhs: &SpannedAtom<T>,
+        rhs: &SpannedAtom<T>,
         arithmetic: &dyn OrdArithmetic<T>,
-    ) -> EvalResult<'a, T> {
+    ) -> EvalResult<T> {
         let lhs_value = lhs.copy_with_extra(self.resolve_atom(&lhs.extra));
         let rhs_value = rhs.copy_with_extra(self.resolve_atom(&rhs.extra));
 
@@ -496,11 +427,7 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
         }
     }
 
-    fn access_index_field(
-        &self,
-        receiver: &Atom<T>,
-        index: usize,
-    ) -> Result<Value<'a, T>, ErrorKind> {
+    fn access_index_field(&self, receiver: &Atom<T>, index: usize) -> Result<Value<T>, ErrorKind> {
         let receiver = match receiver {
             Atom::Register(idx) => &self.registers[*idx],
             Atom::Constant(_) => {
@@ -523,11 +450,7 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
         }
     }
 
-    fn access_named_field(
-        &self,
-        receiver: &Atom<T>,
-        name: &str,
-    ) -> Result<Value<'a, T>, ErrorKind> {
+    fn access_named_field(&self, receiver: &Atom<T>, name: &str) -> Result<Value<T>, ErrorKind> {
         let Atom::Register(idx) = receiver else {
             return Err(ErrorKind::CannotAccessFields);
         };
@@ -541,14 +464,14 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
 
     #[allow(clippy::needless_option_as_deref)] // false positive
     fn eval_function(
-        function: &Function<'a, T>,
+        function: &Function<T>,
         fn_name: &str,
         module_id: &dyn ModuleId,
-        call_span: MaybeSpanned<'a>,
-        arg_values: Vec<SpannedValue<'a, T>>,
+        call_span: MaybeSpanned,
+        arg_values: Vec<SpannedValue<T>>,
         operations: Operations<'_, T>,
-        mut backtrace: Option<&mut Backtrace<'a>>,
-    ) -> EvalResult<'a, T> {
+        mut backtrace: Option<&mut Backtrace>,
+    ) -> EvalResult<T> {
         let full_call_span = CodeInModule::new(module_id, call_span);
         if let Some(backtrace) = &mut backtrace {
             backtrace.push_call(fn_name, function.def_span(), full_call_span.clone());
@@ -564,7 +487,7 @@ impl<'a, T: 'static + Clone> Registers<'a, T> {
     }
 
     #[inline]
-    fn resolve_atom(&self, atom: &Atom<T>) -> Value<'a, T> {
+    fn resolve_atom(&self, atom: &Atom<T>) -> Value<T> {
         match atom {
             Atom::Register(index) => self.registers[*index].clone(),
             Atom::Constant(value) => Value::Prim(value.clone()),

--- a/eval/src/fns/array.rs
+++ b/eval/src/fns/array.rs
@@ -46,9 +46,9 @@ where
 {
     fn evaluate<'a>(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let generation_fn = extract_fn(
             ctx,
@@ -112,11 +112,11 @@ where
 pub struct Len;
 
 impl<T: FromPrimitive> NativeFn<T> for Len {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 1)?;
         let arg = args.pop().unwrap();
 
@@ -171,11 +171,11 @@ impl<T: FromPrimitive> NativeFn<T> for Len {
 pub struct Map;
 
 impl<T: 'static + Clone> NativeFn<T> for Map {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let map_fn = extract_fn(
             ctx,
@@ -233,11 +233,11 @@ impl<T: 'static + Clone> NativeFn<T> for Map {
 pub struct Filter;
 
 impl<T: 'static + Clone> NativeFn<T> for Filter {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let filter_fn = extract_fn(
             ctx,
@@ -301,11 +301,11 @@ impl<T: 'static + Clone> NativeFn<T> for Filter {
 pub struct Fold;
 
 impl<T: 'static + Clone> NativeFn<T> for Fold {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 3)?;
         let fold_fn = extract_fn(
             ctx,
@@ -368,11 +368,11 @@ impl<T: 'static + Clone> NativeFn<T> for Fold {
 pub struct Push;
 
 impl<T> NativeFn<T> for Push {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let elem = args.pop().unwrap().extra;
         let mut array = extract_array(
@@ -421,11 +421,11 @@ impl<T> NativeFn<T> for Push {
 pub struct Merge;
 
 impl<T: Clone> NativeFn<T> for Merge {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let second = extract_array(
             ctx,
@@ -477,11 +477,11 @@ impl<T: Clone> NativeFn<T> for Merge {
 pub struct Any;
 
 impl<T: Clone + 'static> NativeFn<T> for Any {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let predicate = extract_fn(
             ctx,
@@ -547,11 +547,11 @@ impl<T: Clone + 'static> NativeFn<T> for Any {
 pub struct All;
 
 impl<T: Clone + 'static> NativeFn<T> for All {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 2)?;
         let predicate = extract_fn(
             ctx,

--- a/eval/src/fns/array.rs
+++ b/eval/src/fns/array.rs
@@ -71,7 +71,7 @@ where
 
             let cmp = ctx.arithmetic().partial_cmp(&next_index, &len);
             if matches!(cmp, Some(Ordering::Less | Ordering::Equal)) {
-                let spanned = ctx.apply_call_span(Value::Prim(index));
+                let spanned = ctx.apply_call_location(Value::Prim(index));
                 array.push(generation_fn.evaluate(vec![spanned], ctx)?);
                 index = next_index;
             } else {
@@ -127,7 +127,7 @@ impl<T: FromPrimitive> NativeFn<T> for Len {
                 let err = ErrorKind::native("`len` requires object or tuple arg");
                 return Err(ctx
                     .call_site_error(err)
-                    .with_span(&arg, AuxErrorInfo::InvalidArg));
+                    .with_location(&arg, AuxErrorInfo::InvalidArg));
             }
         };
         let len = T::from_usize(len).ok_or_else(|| {
@@ -191,7 +191,7 @@ impl<T: 'static + Clone> NativeFn<T> for Map {
         let mapped: Result<Tuple<_>, _> = array
             .into_iter()
             .map(|value| {
-                let spanned = ctx.apply_call_span(value);
+                let spanned = ctx.apply_call_location(value);
                 map_fn.evaluate(vec![spanned], ctx)
             })
             .collect();
@@ -252,7 +252,7 @@ impl<T: 'static + Clone> NativeFn<T> for Filter {
 
         let mut filtered = vec![];
         for value in array {
-            let spanned = ctx.apply_call_span(value.clone());
+            let spanned = ctx.apply_call_location(value.clone());
             match filter_fn.evaluate(vec![spanned], ctx)? {
                 Value::Bool(true) => filtered.push(value),
                 Value::Bool(false) => { /* do nothing */ }
@@ -320,7 +320,7 @@ impl<T: 'static + Clone> NativeFn<T> for Fold {
         )?;
 
         array.into_iter().try_fold(acc, |acc, value| {
-            let spanned_args = vec![ctx.apply_call_span(acc), ctx.apply_call_span(value)];
+            let spanned_args = vec![ctx.apply_call_location(acc), ctx.apply_call_location(value)];
             fold_fn.evaluate(spanned_args, ctx)
         })
     }
@@ -495,7 +495,7 @@ impl<T: Clone + 'static> NativeFn<T> for Any {
         )?;
 
         for value in array {
-            let spanned = ctx.apply_call_span(value);
+            let spanned = ctx.apply_call_location(value);
             let result = predicate.evaluate(vec![spanned], ctx)?;
             match result {
                 Value::Bool(false) => { /* continue */ }
@@ -565,7 +565,7 @@ impl<T: Clone + 'static> NativeFn<T> for All {
         )?;
 
         for value in array {
-            let spanned = ctx.apply_call_span(value);
+            let spanned = ctx.apply_call_location(value);
             let result = predicate.evaluate(vec![spanned], ctx)?;
             match result {
                 Value::Bool(false) => return Ok(Value::Bool(false)),

--- a/eval/src/fns/assertions.rs
+++ b/eval/src/fns/assertions.rs
@@ -30,17 +30,20 @@ use crate::{
 ///     assert(1 + 2 != 5); // this assertion is fine
 ///     assert(3^2 > 10); // this one will fail
 /// "#;
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test_assert", &program)?;
+/// let module = Untyped::<F32Grammar>::parse_statements(program)?;
+/// let module = ExecutableModule::new("test_assert", &module)?;
 ///
 /// let mut env = Environment::new();
 /// env.insert_native_fn("assert", fns::Assert);
 ///
 /// let err = module.with_env(&env)?.run().unwrap_err();
-/// assert_eq!(*err.source().location().in_module().fragment(), "assert(3^2 > 10)");
+/// assert_eq!(
+///     err.source().location().in_module().span(&program),
+///     "assert(3^2 > 10)"
+/// );
 /// assert_matches!(
 ///     err.source().kind(),
-///     ErrorKind::NativeCall(ref msg) if msg == "Assertion failed: 3^2 > 10"
+///     ErrorKind::NativeCall(msg) if msg == "Assertion failed"
 /// );
 /// # Ok(())
 /// # }
@@ -104,17 +107,20 @@ fn create_error_with_values<T: fmt::Display>(
 ///     assert_eq(1 + 2, 3); // this assertion is fine
 ///     assert_eq(3^2, 10); // this one will fail
 /// "#;
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test_assert", &program)?;
+/// let module = Untyped::<F32Grammar>::parse_statements(program)?;
+/// let module = ExecutableModule::new("test_assert", &module)?;
 ///
 /// let mut env = Environment::new();
 /// env.insert_native_fn("assert_eq", fns::AssertEq);
 ///
 /// let err = module.with_env(&env)?.run().unwrap_err();
-/// assert_eq!(*err.source().location().in_module().fragment(), "assert_eq(3^2, 10)");
+/// assert_eq!(
+///     err.source().location().in_module().span(program),
+///     "assert_eq(3^2, 10)"
+/// );
 /// assert_matches!(
 ///     err.source().kind(),
-///     ErrorKind::NativeCall(ref msg) if msg == "Assertion failed: 3^2 == 10"
+///     ErrorKind::NativeCall(msg) if msg == "Equality assertion failed"
 /// );
 /// # Ok(())
 /// # }
@@ -163,8 +169,8 @@ impl<T: fmt::Display> NativeFn<T> for AssertEq {
 ///     assert_close(sqrt(9), 3); // this assertion is fine
 ///     assert_close(sqrt(10), 3); // this one should fail
 /// "#;
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test_assert", &program)?;
+/// let module = Untyped::<F32Grammar>::parse_statements(program)?;
+/// let module = ExecutableModule::new("test_assert", &module)?;
 ///
 /// let mut env = Environment::new();
 /// env.insert_native_fn("assert_close", fns::AssertClose::new(1e-4))
@@ -172,7 +178,7 @@ impl<T: fmt::Display> NativeFn<T> for AssertEq {
 ///
 /// let err = module.with_env(&env)?.run().unwrap_err();
 /// assert_eq!(
-///     *err.source().location().in_module().fragment(),
+///     err.source().location().in_module().span(program),
 ///     "assert_close(sqrt(10), 3)"
 /// );
 /// # Ok(())
@@ -247,7 +253,7 @@ impl<T: Clone + fmt::Display> NativeFn<T> for AssertClose<T> {
 /// (using [`arithmetic-typing`](https://docs.rs/arithmetic-typing/) notation)
 ///
 /// ```text
-/// () -> 'T
+/// (() -> 'T) -> ()
 /// ```
 ///
 /// # Examples
@@ -262,15 +268,15 @@ impl<T: Clone + fmt::Display> NativeFn<T> for AssertClose<T> {
 ///     assert_fails(|| obj.x + obj.y); // pass: `obj.y` is not defined
 ///     assert_fails(|| obj.x); // fail: function executes successfully
 /// "#;
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test_assert", &program)?;
+/// let module = Untyped::<F32Grammar>::parse_statements(program)?;
+/// let module = ExecutableModule::new("test_assert", &module)?;
 ///
 /// let mut env = Environment::new();
 /// env.insert_native_fn("assert_fails", fns::AssertFails::default());
 ///
 /// let err = module.with_env(&env)?.run().unwrap_err();
 /// assert_eq!(
-///     *err.source().location().in_module().fragment(),
+///     err.source().location().in_module().span(program),
 ///     "assert_fails(|| obj.x)"
 /// );
 /// # Ok(())
@@ -292,15 +298,15 @@ impl<T: Clone + fmt::Display> NativeFn<T> for AssertClose<T> {
 ///     assert_fails(|| assert_fails(1)); // pass: native error
 ///     assert_fails(assert_fails); // fail: arg len mismatch
 /// "#;
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test_assert", &program)?;
+/// let module = Untyped::<F32Grammar>::parse_statements(program)?;
+/// let module = ExecutableModule::new("test_assert", &module)?;
 ///
 /// let mut env = Environment::new();
 /// env.insert_native_fn("assert_fails", assert_fails);
 ///
 /// let err = module.with_env(&env)?.run().unwrap_err();
 /// assert_eq!(
-///     *err.source().location().in_module().fragment(),
+///     err.source().location().in_module().span(program),
 ///     "assert_fails(assert_fails)"
 /// );
 /// # Ok(())

--- a/eval/src/fns/flow.rs
+++ b/eval/src/fns/flow.rs
@@ -70,7 +70,7 @@ impl<T> NativeFn<T> for If {
             let err = ErrorKind::native("`if` requires first arg to be boolean");
             Err(ctx
                 .call_site_error(err)
-                .with_span(&args[0], AuxErrorInfo::InvalidArg))
+                .with_location(&args[0], AuxErrorInfo::InvalidArg))
         }
     }
 }

--- a/eval/src/fns/flow.rs
+++ b/eval/src/fns/flow.rs
@@ -55,11 +55,11 @@ use crate::{
 pub struct If;
 
 impl<T> NativeFn<T> for If {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 3)?;
         let else_val = args.pop().unwrap().extra;
         let then_val = args.pop().unwrap().extra;
@@ -116,11 +116,11 @@ impl<T> NativeFn<T> for If {
 pub struct While;
 
 impl<T: 'static + Clone> NativeFn<T> for While {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         ctx.check_args_count(&args, 3)?;
 
         let step_fn = extract_fn(

--- a/eval/src/fns/std.rs
+++ b/eval/src/fns/std.rs
@@ -48,7 +48,7 @@ impl<T: fmt::Display> NativeFn<T> for Dbg {
         mut args: Vec<SpannedValue<T>>,
         ctx: &mut CallContext<'_, T>,
     ) -> EvalResult<T> {
-        let module_id = ctx.call_span().module_id();
+        let module_id = ctx.call_location().module_id();
         for arg in &args {
             Self::print_value(module_id, arg);
         }

--- a/eval/src/fns/std.rs
+++ b/eval/src/fns/std.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 use crate::{exec::ModuleId, CallContext, EvalResult, NativeFn, SpannedValue, Value};
-use arithmetic_parser::CodeFragment;
 
 /// Acts similarly to the `dbg!` macro, outputting the argument(s) to stderr and returning
 /// them. If a single argument is provided, it's returned as-is; otherwise, the arguments
@@ -32,33 +31,23 @@ use arithmetic_parser::CodeFragment;
 pub struct Dbg;
 
 impl Dbg {
-    fn print_value<T: fmt::Display>(module_id: &dyn ModuleId, value: &SpannedValue<'_, T>) {
-        match value.fragment() {
-            CodeFragment::Str(code) => eprintln!(
-                "[{module}:{line}:{col}] {code} = {val}",
-                module = module_id,
-                line = value.location_line(),
-                col = value.get_column(),
-                code = code,
-                val = value.extra
-            ),
-            CodeFragment::Stripped(_) => eprintln!(
-                "[{module}:{line}:{col}] {val}",
-                module = module_id,
-                line = value.location_line(),
-                col = value.get_column(),
-                val = value.extra
-            ),
-        }
+    fn print_value<T: fmt::Display>(module_id: &dyn ModuleId, value: &SpannedValue<T>) {
+        eprintln!(
+            "[{module}:{line}:{col}] {val}",
+            module = module_id,
+            line = value.location_line(),
+            col = value.get_column(),
+            val = value.extra
+        );
     }
 }
 
 impl<T: fmt::Display> NativeFn<T> for Dbg {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        mut args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        mut args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         let module_id = ctx.call_span().module_id();
         for arg in &args {
             Self::print_value(module_id, arg);

--- a/eval/src/fns/wrapper/mod.rs
+++ b/eval/src/fns/wrapper/mod.rs
@@ -133,16 +133,16 @@ macro_rules! arity_fn {
         impl<Num, F, Ret, $($t,)*> NativeFn<Num> for FnWrapper<(Ret, $($t,)*), F>
         where
             F: Fn($($t,)*) -> Ret,
-            $($t: for<'val> TryFromValue<'val, Num>,)*
-            Ret: for<'val> IntoEvalResult<'val, Num>,
+            $($t: TryFromValue<Num>,)*
+            Ret: IntoEvalResult<Num>,
         {
             #[allow(clippy::shadow_unrelated)] // makes it easier to write macro
             #[allow(unused_variables, unused_mut)] // `args_iter` is unused for 0-ary functions
-            fn evaluate<'a>(
+            fn evaluate(
                 &self,
-                args: Vec<SpannedValue<'a, Num>>,
-                context: &mut CallContext<'_, 'a, Num>,
-            ) -> EvalResult<'a, Num> {
+                args: Vec<SpannedValue<Num>>,
+                context: &mut CallContext<'_, Num>,
+            ) -> EvalResult<Num> {
                 context.check_args_count(&args, $arity)?;
                 let mut args_iter = args.into_iter().enumerate();
 
@@ -362,7 +362,7 @@ macro_rules! wrap_fn_with_context {
 #[doc(hidden)] // necessary for `wrap_fn` macro
 pub fn enforce_closure_type<T, A, F>(function: F) -> F
 where
-    F: for<'a> Fn(Vec<SpannedValue<'a, T>>, &mut CallContext<'_, 'a, A>) -> EvalResult<'a, T>,
+    F: Fn(Vec<SpannedValue<T>>, &mut CallContext<'_, A>) -> EvalResult<T>,
 {
     function
 }
@@ -543,7 +543,7 @@ mod tests {
     #[test]
     #[allow(clippy::cast_precision_loss)] // fine for this test
     fn function_with_object_and_tuple() -> anyhow::Result<()> {
-        fn test_function(tuple: Tuple<'_, f32>) -> Object<'_, f32> {
+        fn test_function(tuple: Tuple<f32>) -> Object<f32> {
             let mut obj = Object::default();
             obj.insert("len", Value::Prim(tuple.len() as f32));
             obj.insert("tuple", tuple.into());

--- a/eval/src/fns/wrapper/mod.rs
+++ b/eval/src/fns/wrapper/mod.rs
@@ -210,7 +210,7 @@ pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 /// ```
 /// # use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
 /// # use arithmetic_eval::{wrap_fn, Function, Environment, ExecutableModule, Value};
-/// fn is_function<T>(value: Value<'_, T>) -> bool {
+/// fn is_function<T>(value: Value<T>) -> bool {
 ///     value.is_function()
 /// }
 ///
@@ -234,7 +234,7 @@ pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 /// #     wrap_fn, CallContext, Function, Environment, ExecutableModule, Value, env::Prelude,
 /// # };
 /// // Note that both `Value`s have the same lifetime due to elision.
-/// fn take_if<T>(value: Value<'_, T>, condition: bool) -> Value<'_, T> {
+/// fn take_if<T>(value: Value<T>, condition: bool) -> Value<T> {
 ///     if condition { value } else { Value::void() }
 /// }
 ///
@@ -309,11 +309,11 @@ macro_rules! wrap_fn {
 /// # use arithmetic_eval::{
 /// #     wrap_fn_with_context, CallContext, Function, Environment, Value, ExecutableModule, Error,
 /// # };
-/// fn map_array<'a>(
-///     context: &mut CallContext<'_, 'a, f32>,
-///     array: Vec<Value<'a, f32>>,
-///     map_fn: Function<'a, f32>,
-/// ) -> Result<Vec<Value<'a, f32>>, Error<'a>> {
+/// fn map_array(
+///     context: &mut CallContext<'_, f32>,
+///     array: Vec<Value<f32>>,
+///     map_fn: Function<f32>,
+/// ) -> Result<Vec<Value<f32>>, Error> {
 ///     array
 ///         .into_iter()
 ///         .map(|value| {

--- a/eval/src/fns/wrapper/mod.rs
+++ b/eval/src/fns/wrapper/mod.rs
@@ -153,7 +153,7 @@ macro_rules! arity_fn {
                         err.set_arg_index(index);
                         context
                             .call_site_error(ErrorKind::Wrapper(err))
-                            .with_span(&span, AuxErrorInfo::InvalidArg)
+                            .with_location(&span, AuxErrorInfo::InvalidArg)
                     })?;
                 )*
 
@@ -284,7 +284,7 @@ macro_rules! wrap_fn {
                         err.set_arg_index(index);
                         context
                             .call_site_error($crate::error::ErrorKind::Wrapper(err))
-                            .with_span(&span, $crate::error::AuxErrorInfo::InvalidArg)
+                            .with_location(&span, $crate::error::AuxErrorInfo::InvalidArg)
                     })?;
             )+
 
@@ -317,7 +317,7 @@ macro_rules! wrap_fn {
 ///     array
 ///         .into_iter()
 ///         .map(|value| {
-///             let arg = context.apply_call_span(value);
+///             let arg = context.apply_call_location(value);
 ///             map_fn.evaluate(vec![arg], context)
 ///         })
 ///         .collect()

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -259,7 +259,7 @@ mod values;
 /// This trait is somewhat of a crutch, necessary to ensure that [function wrappers] can accept
 /// number arguments and distinguish them from other types (booleans, vectors, tuples, etc.).
 ///
-/// [function wrappers]: crate::fns::FnWrapper
+/// [function wrappers]: fns::FnWrapper
 pub trait Number: Clone + 'static {}
 
 impl Number for i8 {}

--- a/eval/src/values/function.rs
+++ b/eval/src/values/function.rs
@@ -10,23 +10,23 @@ use crate::{
     fns::ValueCell,
     Environment, EvalResult, SpannedValue, Value,
 };
-use arithmetic_parser::{LvalueLen, MaybeSpanned, StripCode};
+use arithmetic_parser::{LvalueLen, MaybeSpanned};
 
 /// Context for native function calls.
 #[derive(Debug)]
-pub struct CallContext<'r, 'a, T> {
-    call_span: CodeInModule<'a>,
-    backtrace: Option<&'r mut Backtrace<'a>>,
+pub struct CallContext<'r, T> {
+    call_span: CodeInModule,
+    backtrace: Option<&'r mut Backtrace>,
     operations: Operations<'r, T>,
 }
 
-impl<'r, 'a, T> CallContext<'r, 'a, T> {
+impl<'r, T> CallContext<'r, T> {
     /// Creates a mock call context with the specified module ID and call span.
     /// The provided [`Environment`] is used to extract an [`OrdArithmetic`] implementation.
     pub fn mock(
         module_id: &dyn ModuleId,
-        call_span: MaybeSpanned<'a>,
-        env: &'r Environment<'a, T>,
+        call_span: MaybeSpanned,
+        env: &'r Environment<T>,
     ) -> Self {
         Self {
             call_span: CodeInModule::new(module_id, call_span),
@@ -36,8 +36,8 @@ impl<'r, 'a, T> CallContext<'r, 'a, T> {
     }
 
     pub(crate) fn new(
-        call_span: CodeInModule<'a>,
-        backtrace: Option<&'r mut Backtrace<'a>>,
+        call_span: CodeInModule,
+        backtrace: Option<&'r mut Backtrace>,
         operations: Operations<'r, T>,
     ) -> Self {
         Self {
@@ -48,7 +48,7 @@ impl<'r, 'a, T> CallContext<'r, 'a, T> {
     }
 
     #[allow(clippy::needless_option_as_deref)] // false positive
-    pub(crate) fn backtrace(&mut self) -> Option<&mut Backtrace<'a>> {
+    pub(crate) fn backtrace(&mut self) -> Option<&mut Backtrace> {
         self.backtrace.as_deref_mut()
     }
 
@@ -57,26 +57,26 @@ impl<'r, 'a, T> CallContext<'r, 'a, T> {
     }
 
     /// Returns the call span of the currently executing function.
-    pub fn call_span(&self) -> &CodeInModule<'a> {
+    pub fn call_span(&self) -> &CodeInModule {
         &self.call_span
     }
 
     /// Applies the call span to the specified `value`.
-    pub fn apply_call_span<U>(&self, value: U) -> MaybeSpanned<'a, U> {
+    pub fn apply_call_span<U>(&self, value: U) -> MaybeSpanned<U> {
         self.call_span.code().copy_with_extra(value)
     }
 
     /// Creates an error spanning the call site.
-    pub fn call_site_error(&self, error: ErrorKind) -> Error<'a> {
+    pub fn call_site_error(&self, error: ErrorKind) -> Error {
         Error::from_parts(self.call_span.clone(), error)
     }
 
     /// Checks argument count and returns an error if it doesn't match.
     pub fn check_args_count(
         &self,
-        args: &[SpannedValue<'a, T>],
+        args: &[SpannedValue<T>],
         expected_count: impl Into<LvalueLen>,
-    ) -> Result<(), Error<'a>> {
+    ) -> Result<(), Error> {
         let expected_count = expected_count.into();
         if expected_count.matches(args.len()) {
             Ok(())
@@ -95,23 +95,22 @@ impl<'r, 'a, T> CallContext<'r, 'a, T> {
 /// code. See [`fns`](crate::fns) module docs for different ways to define native functions.
 pub trait NativeFn<T> {
     /// Executes the function on the specified arguments.
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        args: Vec<SpannedValue<'a, T>>,
-        context: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T>;
+        args: Vec<SpannedValue<T>>,
+        context: &mut CallContext<'_, T>,
+    ) -> EvalResult<T>;
 }
 
 impl<T, F> NativeFn<T> for F
 where
-    F: 'static
-        + for<'a> Fn(Vec<SpannedValue<'a, T>>, &mut CallContext<'_, 'a, T>) -> EvalResult<'a, T>,
+    F: 'static + Fn(Vec<SpannedValue<T>>, &mut CallContext<'_, T>) -> EvalResult<T>,
 {
-    fn evaluate<'a>(
+    fn evaluate(
         &self,
-        args: Vec<SpannedValue<'a, T>>,
-        context: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        args: Vec<SpannedValue<T>>,
+        context: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         self(args, context)
     }
 }
@@ -134,43 +133,17 @@ impl<T> dyn NativeFn<T> {
 }
 
 /// Function defined within the interpreter.
-#[derive(Debug)]
-pub struct InterpretedFn<'a, T> {
-    definition: Rc<ExecutableFn<'a, T>>,
-    captures: Vec<Value<'a, T>>,
+#[derive(Debug, Clone)]
+pub struct InterpretedFn<T> {
+    definition: Rc<ExecutableFn<T>>,
+    captures: Vec<Value<T>>,
     capture_names: Vec<String>,
 }
 
-impl<T: Clone> Clone for InterpretedFn<'_, T> {
-    fn clone(&self) -> Self {
-        Self {
-            definition: Rc::clone(&self.definition),
-            captures: self.captures.clone(),
-            capture_names: self.capture_names.clone(),
-        }
-    }
-}
-
-impl<T: 'static + Clone> StripCode for InterpretedFn<'_, T> {
-    type Stripped = InterpretedFn<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        InterpretedFn {
-            definition: Rc::new(self.definition.to_stripped_code()),
-            captures: self
-                .captures
-                .into_iter()
-                .map(StripCode::strip_code)
-                .collect(),
-            capture_names: self.capture_names,
-        }
-    }
-}
-
-impl<'a, T> InterpretedFn<'a, T> {
+impl<T> InterpretedFn<T> {
     pub(crate) fn new(
-        definition: Rc<ExecutableFn<'a, T>>,
-        captures: Vec<Value<'a, T>>,
+        definition: Rc<ExecutableFn<T>>,
+        captures: Vec<Value<T>>,
         capture_names: Vec<String>,
     ) -> Self {
         Self {
@@ -191,7 +164,7 @@ impl<'a, T> InterpretedFn<'a, T> {
     }
 
     /// Returns values captured by this function.
-    pub fn captures(&self) -> HashMap<&str, &Value<'a, T>> {
+    pub fn captures(&self) -> HashMap<&str, &Value<T>> {
         self.capture_names
             .iter()
             .zip(&self.captures)
@@ -200,19 +173,13 @@ impl<'a, T> InterpretedFn<'a, T> {
     }
 }
 
-impl<T: 'static + Clone> InterpretedFn<'_, T> {
-    fn to_stripped_code(&self) -> InterpretedFn<'static, T> {
-        self.clone().strip_code()
-    }
-}
-
-impl<'a, T: 'static + Clone> InterpretedFn<'a, T> {
+impl<T: 'static + Clone> InterpretedFn<T> {
     /// Evaluates this function with the provided arguments and the execution context.
     pub fn evaluate(
         &self,
-        args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         if !self.arg_count().matches(args.len()) {
             let err = ErrorKind::ArgsLenMismatch {
                 def: self.arg_count(),
@@ -233,7 +200,7 @@ impl<'a, T: 'static + Clone> InterpretedFn<'a, T> {
         self.definition.inner.call_function(captures, args, ctx)
     }
 
-    fn deref_capture(capture: &Value<'a, T>, name: &str) -> Result<Value<'a, T>, ErrorKind> {
+    fn deref_capture(capture: &Value<T>, name: &str) -> Result<Value<T>, ErrorKind> {
         Ok(match capture {
             Value::Ref(opaque_ref) => {
                 if let Some(cell) = opaque_ref.downcast_ref::<ValueCell<T>>() {
@@ -252,14 +219,14 @@ impl<'a, T: 'static + Clone> InterpretedFn<'a, T> {
 /// Function definition. Functions can be either native (defined in the Rust code) or defined
 /// in the interpreter.
 #[derive(Debug)]
-pub enum Function<'a, T> {
+pub enum Function<T> {
     /// Native function.
     Native(Rc<dyn NativeFn<T>>),
     /// Interpreted function.
-    Interpreted(Rc<InterpretedFn<'a, T>>),
+    Interpreted(Rc<InterpretedFn<T>>),
 }
 
-impl<T> Clone for Function<'_, T> {
+impl<T> Clone for Function<T> {
     fn clone(&self) -> Self {
         match self {
             Self::Native(function) => Self::Native(Rc::clone(function)),
@@ -268,7 +235,7 @@ impl<T> Clone for Function<'_, T> {
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Function<'_, T> {
+impl<T: fmt::Display> fmt::Display for Function<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Native(_) => formatter.write_str("(native fn)"),
@@ -283,26 +250,13 @@ impl<T: fmt::Display> fmt::Display for Function<'_, T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for Function<'_, T> {
+impl<T: PartialEq> PartialEq for Function<T> {
     fn eq(&self, other: &Self) -> bool {
         self.is_same_function(other)
     }
 }
 
-impl<T: 'static + Clone> StripCode for Function<'_, T> {
-    type Stripped = Function<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        match self {
-            Self::Native(function) => Function::Native(function),
-            Self::Interpreted(function) => {
-                Function::Interpreted(Rc::new(function.to_stripped_code()))
-            }
-        }
-    }
-}
-
-impl<'a, T> Function<'a, T> {
+impl<T> Function<T> {
     /// Creates a native function.
     pub fn native(function: impl NativeFn<T> + 'static) -> Self {
         Self::Native(Rc::new(function))
@@ -317,7 +271,7 @@ impl<'a, T> Function<'a, T> {
         }
     }
 
-    pub(crate) fn def_span(&self) -> Option<CodeInModule<'a>> {
+    pub(crate) fn def_span(&self) -> Option<CodeInModule> {
         match self {
             Self::Native(_) => None,
             Self::Interpreted(function) => Some(CodeInModule::new(
@@ -328,13 +282,13 @@ impl<'a, T> Function<'a, T> {
     }
 }
 
-impl<'a, T: 'static + Clone> Function<'a, T> {
+impl<T: 'static + Clone> Function<T> {
     /// Evaluates the function on the specified arguments.
     pub fn evaluate(
         &self,
-        args: Vec<SpannedValue<'a, T>>,
-        ctx: &mut CallContext<'_, 'a, T>,
-    ) -> EvalResult<'a, T> {
+        args: Vec<SpannedValue<T>>,
+        ctx: &mut CallContext<'_, T>,
+    ) -> EvalResult<T> {
         match self {
             Self::Native(function) => function.evaluate(args, ctx),
             Self::Interpreted(function) => function.evaluate(args, ctx),

--- a/eval/src/values/mod.rs
+++ b/eval/src/values/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     alloc::{Rc, Vec},
     fns,
 };
-use arithmetic_parser::MaybeSpanned;
+use arithmetic_parser::Location;
 
 mod function;
 mod object;
@@ -186,7 +186,7 @@ pub enum Value<T> {
 }
 
 /// Value together with a span that has produced it.
-pub type SpannedValue<T> = MaybeSpanned<Value<T>>;
+pub type SpannedValue<T> = Location<Value<T>>;
 
 impl<T> Value<T> {
     /// Creates a value for a native function.

--- a/eval/src/values/ops.rs
+++ b/eval/src/values/ops.rs
@@ -8,7 +8,7 @@ use crate::{
     exec::ModuleId,
     Object, Tuple, Value,
 };
-use arithmetic_parser::{BinaryOp, MaybeSpanned, Op, UnaryOp};
+use arithmetic_parser::{BinaryOp, Location, Op, UnaryOp};
 
 #[derive(Debug, Clone, Copy)]
 enum OpSide {
@@ -65,9 +65,9 @@ impl BinaryOpError {
     fn span(
         self,
         module_id: &dyn ModuleId,
-        total_span: MaybeSpanned,
-        lhs_span: MaybeSpanned,
-        rhs_span: MaybeSpanned,
+        total_span: Location,
+        lhs_span: Location,
+        rhs_span: Location,
     ) -> Error {
         let main_span = match self.side {
             Some(OpSide::Lhs) => lhs_span,
@@ -85,7 +85,7 @@ impl BinaryOpError {
 
         let mut err = Error::new(module_id, &main_span, self.inner);
         if let Some(aux_info) = aux_info {
-            err = err.with_span(&rhs_span, aux_info);
+            err = err.with_location(&rhs_span, aux_info);
         }
         err
     }
@@ -192,9 +192,9 @@ impl<T: Clone> Value<T> {
     #[inline]
     pub(crate) fn try_binary_op(
         module_id: &dyn ModuleId,
-        total_span: MaybeSpanned,
-        lhs: MaybeSpanned<Self>,
-        rhs: MaybeSpanned<Self>,
+        total_span: Location,
+        lhs: Location<Self>,
+        rhs: Location<Self>,
         op: BinaryOp,
         arithmetic: &dyn OrdArithmetic<T>,
     ) -> Result<Self, Error> {
@@ -273,8 +273,8 @@ impl<T> Value<T> {
 
     pub(crate) fn compare(
         module_id: &dyn ModuleId,
-        lhs: &MaybeSpanned<Self>,
-        rhs: &MaybeSpanned<Self>,
+        lhs: &Location<Self>,
+        rhs: &Location<Self>,
         op: BinaryOp,
         arithmetic: &dyn OrdArithmetic<T>,
     ) -> Result<Self, Error> {
@@ -299,8 +299,8 @@ impl<T> Value<T> {
 
     pub(crate) fn try_and(
         module_id: &dyn ModuleId,
-        lhs: &MaybeSpanned<Self>,
-        rhs: &MaybeSpanned<Self>,
+        lhs: &Location<Self>,
+        rhs: &Location<Self>,
     ) -> Result<Self, Error> {
         match (&lhs.extra, &rhs.extra) {
             (Value::Bool(this), Value::Bool(other)) => Ok(Value::Bool(*this && *other)),
@@ -321,8 +321,8 @@ impl<T> Value<T> {
 
     pub(crate) fn try_or(
         module_id: &dyn ModuleId,
-        lhs: &MaybeSpanned<Self>,
-        rhs: &MaybeSpanned<Self>,
+        lhs: &Location<Self>,
+        rhs: &Location<Self>,
     ) -> Result<Self, Error> {
         match (&lhs.extra, &rhs.extra) {
             (Value::Bool(this), Value::Bool(other)) => Ok(Value::Bool(*this || *other)),

--- a/eval/src/values/tuple.rs
+++ b/eval/src/values/tuple.rs
@@ -6,7 +6,6 @@ use crate::{
     alloc::{vec, Vec},
     Value,
 };
-use arithmetic_parser::StripCode;
 
 /// Tuple of zero or more values.
 ///
@@ -30,35 +29,35 @@ use arithmetic_parser::StripCode;
 /// assert_eq!(other_tuple.len(), 5);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct Tuple<'a, T> {
-    elements: Vec<Value<'a, T>>,
+pub struct Tuple<T> {
+    elements: Vec<Value<T>>,
 }
 
-impl<'a, T> Default for Tuple<'a, T> {
+impl<T> Default for Tuple<T> {
     fn default() -> Self {
         Self::void()
     }
 }
 
-impl<'a, T> From<Tuple<'a, T>> for Value<'a, T> {
-    fn from(tuple: Tuple<'a, T>) -> Self {
+impl<T> From<Tuple<T>> for Value<T> {
+    fn from(tuple: Tuple<T>) -> Self {
         Self::Tuple(tuple)
     }
 }
 
-impl<'a, T> From<Vec<Value<'a, T>>> for Tuple<'a, T> {
-    fn from(elements: Vec<Value<'a, T>>) -> Self {
+impl<T> From<Vec<Value<T>>> for Tuple<T> {
+    fn from(elements: Vec<Value<T>>) -> Self {
         Self { elements }
     }
 }
 
-impl<'a, T> From<Tuple<'a, T>> for Vec<Value<'a, T>> {
-    fn from(tuple: Tuple<'a, T>) -> Self {
+impl<T> From<Tuple<T>> for Vec<Value<T>> {
+    fn from(tuple: Tuple<T>) -> Self {
         tuple.elements
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Tuple<'_, T> {
+impl<T: fmt::Display> fmt::Display for Tuple<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "(")?;
         for (i, element) in self.iter().enumerate() {
@@ -73,7 +72,7 @@ impl<T: fmt::Display> fmt::Display for Tuple<'_, T> {
     }
 }
 
-impl<'a, T> Tuple<'a, T> {
+impl<T> Tuple<T> {
     /// Creates a new empty tuple (aka a void value).
     pub const fn void() -> Self {
         Self {
@@ -92,57 +91,47 @@ impl<'a, T> Tuple<'a, T> {
     }
 
     /// Iterates over the elements in this tuple.
-    pub fn iter(&self) -> impl Iterator<Item = &Value<'a, T>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &Value<T>> + '_ {
         self.elements.iter()
     }
 
     /// Pushes a value to the end of this tuple.
-    pub fn push(&mut self, value: impl Into<Value<'a, T>>) {
+    pub fn push(&mut self, value: impl Into<Value<T>>) {
         self.elements.push(value.into());
     }
 }
 
-impl<T: 'static + Clone> StripCode for Tuple<'_, T> {
-    type Stripped = Tuple<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        Tuple {
-            elements: self.elements.into_iter().map(Value::strip_code).collect(),
-        }
-    }
-}
-
-impl<'a, T> ops::Index<usize> for Tuple<'a, T> {
-    type Output = Value<'a, T>;
+impl<T> ops::Index<usize> for Tuple<T> {
+    type Output = Value<T>;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.elements[index]
     }
 }
 
-impl<'a, T> IntoIterator for Tuple<'a, T> {
-    type Item = Value<'a, T>;
+impl<T> IntoIterator for Tuple<T> {
+    type Item = Value<T>;
     /// Iterator type should be considered an implementation detail.
-    type IntoIter = vec::IntoIter<Value<'a, T>>;
+    type IntoIter = vec::IntoIter<Value<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements.into_iter()
     }
 }
 
-impl<'r, 'a, T> IntoIterator for &'r Tuple<'a, T> {
-    type Item = &'r Value<'a, T>;
+impl<'r, T> IntoIterator for &'r Tuple<T> {
+    type Item = &'r Value<T>;
     /// Iterator type should be considered an implementation detail.
-    type IntoIter = core::slice::Iter<'r, Value<'a, T>>;
+    type IntoIter = core::slice::Iter<'r, Value<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements.iter()
     }
 }
 
-impl<'a, T, V> FromIterator<V> for Tuple<'a, T>
+impl<T, V> FromIterator<V> for Tuple<T>
 where
-    V: Into<Value<'a, T>>,
+    V: Into<Value<T>>,
 {
     fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
         Self {
@@ -151,9 +140,9 @@ where
     }
 }
 
-impl<'a, T, V> Extend<V> for Tuple<'a, T>
+impl<T, V> Extend<V> for Tuple<T>
 where
-    V: Into<Value<'a, T>>,
+    V: Into<Value<T>>,
 {
     fn extend<I: IntoIterator<Item = V>>(&mut self, iter: I) {
         let new_elements = iter.into_iter().map(Into::into);

--- a/eval/tests/integration/custom_cmp.rs
+++ b/eval/tests/integration/custom_cmp.rs
@@ -11,7 +11,7 @@ use arithmetic_parser::grammars::{NumGrammar, Parse, Untyped};
 
 type ComplexGrammar = NumGrammar<Complex64>;
 
-fn compile_module(program: &str) -> ExecutableModule<'_, Complex64> {
+fn compile_module(program: &str) -> ExecutableModule<Complex64> {
     let block = Untyped::<ComplexGrammar>::parse_statements(program).unwrap();
     ExecutableModule::new("custom_cmp", &block).unwrap()
 }

--- a/eval/tests/integration/functions.rs
+++ b/eval/tests/integration/functions.rs
@@ -362,7 +362,7 @@ fn native_fn_error() {
     let program = "1 + sin(-5.0, 2.0)";
     let err = try_evaluate(&mut env, program).unwrap_err();
     let err = err.source();
-    assert_eq!(err.main_span().code().span_code(program), "sin(-5.0, 2.0)");
+    assert_eq!(err.location().in_module().span(program), "sin(-5.0, 2.0)");
     assert_matches!(
         err.kind(),
         ErrorKind::ArgsLenMismatch {
@@ -375,7 +375,7 @@ fn native_fn_error() {
     let err = try_evaluate(&mut env, other_program).unwrap_err();
     let err = err.source();
     assert_eq!(
-        err.main_span().code().span_code(other_program),
+        err.location().in_module().span(other_program),
         "sin((-5, 2))"
     );
 

--- a/eval/tests/integration/functions.rs
+++ b/eval/tests/integration/functions.rs
@@ -362,7 +362,7 @@ fn native_fn_error() {
     let program = "1 + sin(-5.0, 2.0)";
     let err = try_evaluate(&mut env, program).unwrap_err();
     let err = err.source();
-    assert_eq!(*err.main_span().code().fragment(), "sin(-5.0, 2.0)");
+    assert_eq!(err.main_span().code().span_code(program), "sin(-5.0, 2.0)");
     assert_matches!(
         err.kind(),
         ErrorKind::ArgsLenMismatch {
@@ -374,7 +374,10 @@ fn native_fn_error() {
     let other_program = "1 + sin((-5, 2))";
     let err = try_evaluate(&mut env, other_program).unwrap_err();
     let err = err.source();
-    assert_eq!(*err.main_span().code().fragment(), "sin((-5, 2))");
+    assert_eq!(
+        err.main_span().code().span_code(other_program),
+        "sin((-5, 2))"
+    );
 
     let expected_err_kind = FromValueErrorKind::InvalidType {
         expected: ValueType::Prim,

--- a/eval/tests/integration/hof.rs
+++ b/eval/tests/integration/hof.rs
@@ -27,7 +27,7 @@ impl<T: 'static + Clone> NativeFn<T> for Repeated<T> {
         let mut arg = args.pop().unwrap();
         for _ in 0..self.times {
             let result = self.inner.evaluate(vec![arg], context)?;
-            arg = context.apply_call_span(result);
+            arg = context.apply_call_location(result);
         }
         Ok(arg.extra)
     }
@@ -55,7 +55,7 @@ fn eager_repeat(
         Err(context.call_site_error(ErrorKind::native("`times` should be positive")))
     } else {
         for _ in 0..times as usize {
-            arg = function.evaluate(vec![context.apply_call_span(arg)], context)?;
+            arg = function.evaluate(vec![context.apply_call_location(arg)], context)?;
         }
         Ok(arg)
     }

--- a/eval/tests/integration/integers.rs
+++ b/eval/tests/integration/integers.rs
@@ -82,8 +82,8 @@ where
         err_kind,
         ErrorKind::Arithmetic(err) if err.to_string().contains("integer overflow")
     );
-    let err_span = err.source().main_span().code();
-    assert_eq!(err_span.span_code(program), "1 - 2");
+    let err_span = err.source().location().in_module();
+    assert_eq!(err_span.span(program), "1 - 2");
 }
 
 #[test]
@@ -139,8 +139,8 @@ where
         err_kind,
         ErrorKind::Arithmetic(err) if err.to_string().contains("division by zero")
     );
-    let err_span = err.source().main_span().code();
-    assert_eq!(err_span.span_code(program), "-2 / 0");
+    let err_span = err.source().location().in_module();
+    assert_eq!(err_span.span(program), "-2 / 0");
 
     let program = "2 ^ -3 + 1";
     let err =
@@ -150,8 +150,8 @@ where
         err_kind,
         ErrorKind::Arithmetic(err) if err.to_string().contains("exponent is too large or negative")
     );
-    let err_span = err.source().main_span().code();
-    assert_eq!(err_span.span_code(program), "2 ^ -3");
+    let err_span = err.source().location().in_module();
+    assert_eq!(err_span.span(program), "2 ^ -3");
 }
 
 #[test]

--- a/eval/tests/integration/objects.rs
+++ b/eval/tests/integration/objects.rs
@@ -196,7 +196,7 @@ fn calling_non_callable_field() {
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
     assert_matches!(err.source().kind(), ErrorKind::CannotCall);
     assert_eq!(
-        *err.source().main_span().code().fragment(),
+        err.source().main_span().code().span_code(program),
         "(#{ x: 3, y: 4 }.x)()"
     );
 
@@ -215,7 +215,7 @@ fn field_invalid_receiver_error() {
     let program = "xs = (1, 2, 3); xs.len == 3";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
 
-    assert_eq!(*err.source().main_span().code().fragment(), "xs.len");
+    assert_eq!(err.source().main_span().code().span_code(program), "xs.len");
     assert_matches!(err.source().kind(), ErrorKind::CannotAccessFields);
 }
 
@@ -224,7 +224,7 @@ fn no_field_error() {
     let program = "pt = #{ x: 1, y: 2 }; pt.z";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
 
-    assert_eq!(*err.source().main_span().code().fragment(), "pt.z");
+    assert_eq!(err.source().main_span().code().span_code(program), "pt.z");
     assert_matches!(
         err.source().kind(),
         ErrorKind::NoField { field, available_fields }
@@ -307,7 +307,7 @@ fn object_destructuring_on_non_object() {
     ];
     for &program in programs {
         let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
-        assert_eq!(*err.source().main_span().code().fragment(), "x");
+        assert_eq!(err.source().main_span().code().span_code(program), "x");
         assert_matches!(err.source().kind(), ErrorKind::CannotAccessFields);
     }
 }
@@ -316,12 +316,12 @@ fn object_destructuring_on_non_object() {
 fn object_destructuring_with_missing_field() {
     let program = "{ x, y: Y } = #{ x: 1 };";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
-    assert_eq!(*err.source().main_span().code().fragment(), "y");
+    assert_eq!(err.source().main_span().code().span_code(program), "y");
     assert_matches!(err.source().kind(), ErrorKind::NoField { field, .. } if field == "y");
 
     let program = "({ x, y }, ...pts) = (#{ x: 1 }, #{ x: 2 });";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
-    assert_eq!(*err.source().main_span().code().fragment(), "y");
+    assert_eq!(err.source().main_span().code().span_code(program), "y");
     assert_matches!(err.source().kind(), ErrorKind::NoField { field, .. } if field == "y");
 }
 
@@ -329,7 +329,10 @@ fn object_destructuring_with_missing_field() {
 fn embedded_destructuring_error() {
     let program = "{ x, y: (y, ...) } = #{ x: 1, y: 2 };";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
-    assert_eq!(*err.source().main_span().code().fragment(), "(y, ...)");
+    assert_eq!(
+        err.source().main_span().code().span_code(program),
+        "(y, ...)"
+    );
     assert_matches!(err.source().kind(), ErrorKind::CannotDestructure);
 }
 
@@ -339,13 +342,13 @@ fn object_initialization_repeated_fields() {
     let err = expect_compilation_error(program);
     let err_span = err.main_span().code();
 
-    assert_eq!(*err_span.fragment(), "x");
+    assert_eq!(err_span.span_code(program), "x");
     assert_eq!(err_span.location_offset(), 9);
     assert_matches!(err.kind(), ErrorKind::RepeatedField);
 
     assert_eq!(err.aux_spans().len(), 1);
     let aux_span = err.aux_spans()[0].code();
-    assert_eq!(*aux_span.fragment(), "x");
+    assert_eq!(aux_span.span_code(program), "x");
     assert_eq!(aux_span.location_offset(), 3);
     assert_matches!(aux_span.extra, AuxErrorInfo::PrevAssignment);
 }
@@ -356,7 +359,7 @@ fn object_initialization_repeated_fields_with_shorthand() {
     let err = expect_compilation_error(program);
     let err_span = err.main_span().code();
 
-    assert_eq!(*err_span.fragment(), "x");
+    assert_eq!(err_span.span_code(program), "x");
     assert_eq!(err_span.location_offset(), 20);
     assert_matches!(err.kind(), ErrorKind::RepeatedField);
 }
@@ -367,13 +370,13 @@ fn object_destructuring_repeated_fields() {
     let err = expect_compilation_error(program);
     let err_span = err.main_span().code();
 
-    assert_eq!(*err_span.fragment(), "x");
+    assert_eq!(err_span.span_code(program), "x");
     assert_eq!(err_span.location_offset(), 5);
     assert_matches!(err.kind(), ErrorKind::RepeatedField);
 
     assert_eq!(err.aux_spans().len(), 1);
     let aux_span = err.aux_spans()[0].code();
-    assert_eq!(*aux_span.fragment(), "x");
+    assert_eq!(aux_span.span_code(program), "x");
     assert_eq!(aux_span.location_offset(), 2);
     assert_matches!(aux_span.extra, AuxErrorInfo::PrevAssignment);
 }
@@ -384,13 +387,13 @@ fn object_destructuring_repeated_assignment() {
     let err = expect_compilation_error(program);
     let err_span = err.main_span().code();
 
-    assert_eq!(*err_span.fragment(), "x");
+    assert_eq!(err_span.span_code(program), "x");
     assert_eq!(err_span.location_offset(), 8);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment { .. });
 
     assert_eq!(err.aux_spans().len(), 1);
     let aux_span = err.aux_spans()[0].code();
-    assert_eq!(*aux_span.fragment(), "x");
+    assert_eq!(aux_span.span_code(program), "x");
     assert_eq!(aux_span.location_offset(), 2);
     assert_matches!(aux_span.extra, AuxErrorInfo::PrevAssignment);
 }
@@ -401,13 +404,13 @@ fn object_destructuring_repeated_assignment_complex() {
     let err = expect_compilation_error(program);
     let err_span = err.main_span().code();
 
-    assert_eq!(*err_span.fragment(), "x");
+    assert_eq!(err_span.span_code(program), "x");
     assert_eq!(err_span.location_offset(), 10);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment { .. });
 
     assert_eq!(err.aux_spans().len(), 1);
     let aux_span = err.aux_spans()[0].code();
-    assert_eq!(*aux_span.fragment(), "x");
+    assert_eq!(aux_span.span_code(program), "x");
     assert_eq!(aux_span.location_offset(), 2);
     assert_matches!(aux_span.extra, AuxErrorInfo::PrevAssignment);
 }
@@ -450,23 +453,26 @@ fn error_in_binary_op_on_object_and_invalid_operand() {
     let lhs_program = "#{ x: 3, y: 4 } + || 5";
     {
         let err = try_evaluate(&mut Environment::new(), lhs_program).unwrap_err();
-        let main_span = err.source().main_span().code().fragment();
-        assert_eq!(*main_span, "|| 5");
+        let main_span = err.source().main_span().code().span_code(lhs_program);
+        assert_eq!(main_span, "|| 5");
     }
 
     let rhs_program = "true + #{ x: 3, y: 4 }";
     let mut env = Environment::new();
     env.insert("true", Value::Bool(true));
     let err = try_evaluate(&mut env, rhs_program).unwrap_err();
-    let main_span = err.source().main_span().code().fragment();
-    assert_eq!(*main_span, "true");
+    let main_span = err.source().main_span().code().span_code(rhs_program);
+    assert_eq!(main_span, "true");
 }
 
 #[test]
 fn error_in_binary_ops_on_objects() {
     let program = "#{ x: 1 } + #{ y: 1 }";
     let err = try_evaluate(&mut Environment::new(), program).unwrap_err();
-    assert_eq!(*err.source().main_span().code().fragment(), "#{ x: 1 }");
+    assert_eq!(
+        err.source().main_span().code().span_code(program),
+        "#{ x: 1 }"
+    );
     assert_matches!(
         err.source().kind(),
         ErrorKind::FieldsMismatch { op: BinaryOp::Add, lhs_fields, rhs_fields }

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -18,6 +18,12 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Bump minimum supported Rust version to 1.65 and switch to 2021 Rust edition. (#107, #108, #112)
 
+- Remove `MaybeSpanned` type in favor of `Location`. (#121)
+
+### Removed
+
+- Remove `StripCode` and `StripResultExt` traits as obsolete. (#121)
+
 ## 0.3.0 - 2021-05-24
 
 ### Added

--- a/parser/src/grammars/traits.rs
+++ b/parser/src/grammars/traits.rs
@@ -188,6 +188,7 @@ pub trait Grammar<'a>: ParseLiteral {
     ///
     /// The output should follow `nom` conventions on errors / failures.
     fn parse_type(input: InputSpan<'a>) -> NomResult<'a, Self::Type>;
+    // FIXME: why is `'a` not here?
 }
 
 /// Helper trait allowing `Parse` to accept multiple types as inputs.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -160,7 +160,7 @@ pub use crate::{
     error::{Context, Error, ErrorKind, SpannedError, UnsupportedType},
     ops::{BinaryOp, Op, OpPriority, UnaryOp},
     parser::is_valid_variable_name,
-    spans::{with_span, InputSpan, LocatedSpan, MaybeSpanned, NomResult, Spanned},
+    spans::{with_span, InputSpan, LocatedSpan, Location, NomResult, Spanned},
 };
 
 mod ast;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -160,10 +160,7 @@ pub use crate::{
     error::{Context, Error, ErrorKind, SpannedError, UnsupportedType},
     ops::{BinaryOp, Op, OpPriority, UnaryOp},
     parser::is_valid_variable_name,
-    spans::{
-        with_span, CodeFragment, InputSpan, LocatedSpan, MaybeSpanned, NomResult, Spanned,
-        StripCode, StripResultExt,
-    },
+    spans::{with_span, InputSpan, LocatedSpan, MaybeSpanned, NomResult, Spanned},
 };
 
 mod ast;

--- a/parser/src/spans.rs
+++ b/parser/src/spans.rs
@@ -3,7 +3,7 @@
 use nom::Slice;
 
 use crate::{
-    alloc::{format, String, ToOwned},
+    alloc::{format, String},
     Error,
 };
 
@@ -151,63 +151,13 @@ impl<'a> Spanned<'a> {
     }
 }
 
-/// Container for a code fragment that can be in one of the two states: either the code string
-/// is retained, or it is stripped away.
-///
-/// The stripped version allows to retain information about code location within [`LocatedSpan`]
-/// without a restriction by the code lifetime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CodeFragment<'a> {
-    /// Original code fragment: a string reference.
-    Str(&'a str),
-    /// Stripped code fragment: just the string length.
-    Stripped(usize),
-}
-
-impl PartialEq<&str> for CodeFragment<'_> {
-    fn eq(&self, &other: &&str) -> bool {
-        match self {
-            Self::Str(string) => *string == other,
-            Self::Stripped(_) => false,
-        }
-    }
-}
-
-impl CodeFragment<'_> {
-    /// Strips this code fragment, extending its lifetime beyond the lifetime of the code.
-    pub fn strip(self) -> CodeFragment<'static> {
-        match self {
-            Self::Str(string) => CodeFragment::Stripped(string.len()),
-            Self::Stripped(len) => CodeFragment::Stripped(len),
-        }
-    }
-
-    /// Gets the length of this code fragment.
-    pub fn len(self) -> usize {
-        match self {
-            Self::Str(string) => string.len(),
-            Self::Stripped(len) => len,
-        }
-    }
-
-    /// Checks if this code fragment is empty.
-    pub fn is_empty(self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl<'a> From<&'a str> for CodeFragment<'a> {
-    fn from(value: &'a str) -> Self {
-        CodeFragment::Str(value)
-    }
-}
-
 /// Value with an optional associated code span.
-pub type MaybeSpanned<'a, T = ()> = LocatedSpan<CodeFragment<'a>, T>;
+pub type MaybeSpanned<T = ()> = LocatedSpan<usize, T>;
+// FIXME: simplify; rename
 
-impl<'a> MaybeSpanned<'a> {
+impl MaybeSpanned {
     /// Creates a span from a `range` in the provided `code`. This is mostly useful for testing.
-    pub fn from_str<R>(code: &'a str, range: R) -> Self
+    pub fn from_str<'a, R>(code: &'a str, range: R) -> Self
     where
         InputSpan<'a>: Slice<R>,
     {
@@ -215,42 +165,22 @@ impl<'a> MaybeSpanned<'a> {
     }
 }
 
-impl<T> MaybeSpanned<'_, T> {
+impl<T> MaybeSpanned<T> {
     /// Returns either the original code fragment (if it's retained), or a string in the form
     /// `{default_name} at {line}:{column}`.
-    pub fn code_or_location(&self, default_name: &str) -> String {
-        match self.fragment {
-            CodeFragment::Str(code) => code.to_owned(),
-            CodeFragment::Stripped(_) => {
-                format!("{default_name} at {}:{}", self.line, self.column)
-            }
-        }
+    pub fn location(&self, default_name: &str) -> String {
+        format!("{default_name} at {}:{}", self.line, self.column)
+    }
+
+    /// Returns this span in the provided `code`.
+    pub fn span_code<'a>(&self, code: &'a str) -> &'a str {
+        &code[self.offset..(self.offset + self.fragment)]
     }
 }
 
-impl<'a, T> From<Spanned<'a, T>> for MaybeSpanned<'a, T> {
-    fn from(value: Spanned<'a, T>) -> Self {
-        value.map_fragment(CodeFragment::from)
-    }
-}
-
-/// Encapsulates stripping references to code fragments. The result can outlive the code.
-///
-/// Implementors of this trait are usually generic by the code lifetime: `Foo<'_, ..>`,
-/// with the result of stripping being `Foo<'static, ..>`.
-pub trait StripCode {
-    /// Resulting type after code stripping.
-    type Stripped: 'static;
-
-    /// Strips references to code fragments in this type.
-    fn strip_code(self) -> Self::Stripped;
-}
-
-impl<T: Clone + 'static> StripCode for MaybeSpanned<'_, T> {
-    type Stripped = MaybeSpanned<'static, T>;
-
-    fn strip_code(self) -> Self::Stripped {
-        self.map_fragment(CodeFragment::strip)
+impl<T> From<Spanned<'_, T>> for MaybeSpanned<T> {
+    fn from(value: Spanned<'_, T>) -> Self {
+        value.map_fragment(str::len)
     }
 }
 
@@ -293,25 +223,5 @@ pub(crate) fn unite_spans<'a, T, U>(
         column: start.column,
         fragment: &input.fragment()[start_idx..end_idx],
         extra: (),
-    }
-}
-
-/// Helper trait for [`Result`]s with the error component that implements [`StripCode`].
-pub trait StripResultExt {
-    /// Type wrapped by the `Result::Ok` variant.
-    type Ok;
-    /// Result of stripping code fragments from an error.
-    type StrippedErr: 'static;
-
-    /// Strips code fragments from the error variant.
-    fn strip_err(self) -> Result<Self::Ok, Self::StrippedErr>;
-}
-
-impl<T, E: StripCode> StripResultExt for Result<T, E> {
-    type Ok = T;
-    type StrippedErr = E::Stripped;
-
-    fn strip_err(self) -> Result<T, Self::StrippedErr> {
-        self.map_err(StripCode::strip_code)
     }
 }

--- a/parser/src/spans.rs
+++ b/parser/src/spans.rs
@@ -151,12 +151,12 @@ impl<'a> Spanned<'a> {
     }
 }
 
-/// Value with an optional associated code span.
-pub type MaybeSpanned<T = ()> = LocatedSpan<usize, T>;
-// FIXME: simplify; rename
+/// Value with an associated code location. Unlike [`Spanned`], `Location` does not retain a reference
+/// to the original code span, just its start position and length.
+pub type Location<T = ()> = LocatedSpan<usize, T>;
 
-impl MaybeSpanned {
-    /// Creates a span from a `range` in the provided `code`. This is mostly useful for testing.
+impl Location {
+    /// Creates a location from a `range` in the provided `code`. This is mostly useful for testing.
     pub fn from_str<'a, R>(code: &'a str, range: R) -> Self
     where
         InputSpan<'a>: Slice<R>,
@@ -165,20 +165,20 @@ impl MaybeSpanned {
     }
 }
 
-impl<T> MaybeSpanned<T> {
-    /// Returns either the original code fragment (if it's retained), or a string in the form
-    /// `{default_name} at {line}:{column}`.
-    pub fn location(&self, default_name: &str) -> String {
+impl<T> Location<T> {
+    /// Returns a string representation of this location in the form `{default_name} at {line}:{column}`.
+    pub fn to_string(&self, default_name: &str) -> String {
         format!("{default_name} at {}:{}", self.line, self.column)
     }
 
-    /// Returns this span in the provided `code`.
-    pub fn span_code<'a>(&self, code: &'a str) -> &'a str {
+    /// Returns this location in the provided `code`. It is caller's responsibility to ensure that this
+    /// is called with the original `code` that produced this location.
+    pub fn span<'a>(&self, code: &'a str) -> &'a str {
         &code[self.offset..(self.offset + self.fragment)]
     }
 }
 
-impl<T> From<Spanned<'_, T>> for MaybeSpanned<T> {
+impl<T> From<Spanned<'_, T>> for Location<T> {
     fn from(value: Spanned<'_, T>) -> Self {
         value.map_fragment(str::len)
     }


### PR DESCRIPTION
## What?

Removes lifetime param in `Value`, `ExecutableModule`, `Error` etc. by stripping code spans when compiling the program.

## Why?

- Lifetimes make types in the eval crate needlessly complex. Removing them enables future improvements, such as removing `wrap_*` macros.
- Lifetime in `Error` prevented boxing it, converting it to `anyhow::Error` etc.
