### PR TITLE
Eval crate: chores after lifetime removal

### DIFF
--- a/eval/CHANGELOG.md
+++ b/eval/CHANGELOG.md
@@ -18,6 +18,8 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Support block expressions in the name position for method calls such as `xs.{Array.map}(|x| x > 0)`. (#117)
 
+- Make `ExecutableModule` thread-safe (`Send + Sync`). (#122)
+
 ### Changed
 
 - Introduce new structs (`Tuple` and `Object`) to represent tuple and object values,
@@ -43,6 +45,9 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 - Remove the lifetime param in `Value`, `ExecutableModule`, `Error` and other types in the crate
   by stripping code spans on compilation. (#121)
 
+- Simplify the `ModuleId` trait: remove its method; use `&Arc<dyn ModuleId>` instead of `&dyn ModuleId`
+  where appropriate. (#122)
+
 ### Removed
 
 - Remove `ExecutableModelBuilder::set_imports()` as error-prone. Instead, deferred imports
@@ -53,6 +58,9 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Remove `loop` native function since it has overly convoluted interface.
   `while` can be used instead. (#105)
+
+- Remove `wrap_fn` and `wrap_fn_with_context` macros as obsolete. This functionality is now
+  fully covered by the `wrap()` function. (#122)
 
 ### Fixed
 

--- a/eval/benches/interpreter.rs
+++ b/eval/benches/interpreter.rs
@@ -107,7 +107,7 @@ fn bench_mul_fold(bencher: &mut Bencher<'_>) {
 
 fn bench_fold_fn(bencher: &mut Bencher<'_>) {
     let env = Environment::new();
-    let mut ctx = CallContext::mock(&WildcardId, Location::from_str("", ..), &env);
+    let mut ctx = CallContext::mock(WildcardId, Location::from_str("", ..), &env);
     let acc = ctx.apply_call_location(Value::Prim(1.0));
     let fold_fn = fns::Binary::new(|x: f32, y| x * y);
     let fold_fn = ctx.apply_call_location(Value::native_fn(fold_fn));
@@ -142,7 +142,7 @@ fn bench_interpreted_fn(bencher: &mut Bencher<'_>) {
 
     let mut rng = StdRng::seed_from_u64(SEED);
     let env = Environment::new();
-    let mut ctx = CallContext::mock(&WildcardId, Location::from_str("", ..), &env);
+    let mut ctx = CallContext::mock(WildcardId, Location::from_str("", ..), &env);
 
     bencher.iter_batched(
         || {
@@ -319,7 +319,7 @@ fn bench_quick_sort_interpreted(bencher: &mut Bencher<'_>) {
             )
         },
         |items| {
-            let mut ctx = CallContext::mock(&"test", Location::from_str("", ..), &env);
+            let mut ctx = CallContext::mock("test", Location::from_str("", ..), &env);
             let items = Location::from_str("", ..).copy_with_extra(items);
             sort_fn.evaluate(vec![items], &mut ctx).unwrap()
         },

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -3,7 +3,7 @@
 use core::iter;
 
 use crate::{
-    alloc::{vec, Box, HashMap, Vec},
+    alloc::{vec, Arc, HashMap, Vec},
     error::{AuxErrorInfo, Error, ErrorKind, RepeatedAssignmentContext},
     exec::{ModuleId, WildcardId},
 };
@@ -16,13 +16,13 @@ use arithmetic_parser::{
 /// variables captured by it.
 #[derive(Debug)]
 pub(super) struct CapturesExtractor<'a> {
-    module_id: Box<dyn ModuleId>,
+    module_id: Arc<dyn ModuleId>,
     local_vars: Vec<HashMap<&'a str, Spanned<'a>>>,
     pub captures: HashMap<&'a str, Spanned<'a>>,
 }
 
 impl<'a> CapturesExtractor<'a> {
-    pub fn new(module_id: Box<dyn ModuleId>) -> Self {
+    pub fn new(module_id: Arc<dyn ModuleId>) -> Self {
         Self {
             module_id,
             local_vars: vec![],
@@ -37,7 +37,7 @@ impl<'a> CapturesExtractor<'a> {
     ) -> Result<(), Error> {
         let mut fn_local_vars = HashMap::new();
         extract_vars(
-            self.module_id.as_ref(),
+            &self.module_id,
             &mut fn_local_vars,
             &definition.args.extra,
             RepeatedAssignmentContext::FnArgs,
@@ -58,7 +58,7 @@ impl<'a> CapturesExtractor<'a> {
     }
 
     fn create_error<T>(&self, span: &Spanned<'a, T>, err: ErrorKind) -> Error {
-        Error::new(self.module_id.as_ref(), span, err)
+        Error::new(self.module_id.clone(), span, err)
     }
 
     /// Evaluates an expression with the function validation semantics, i.e., to determine
@@ -118,7 +118,7 @@ impl<'a> CapturesExtractor<'a> {
                     let field_str = *name.fragment();
                     if let Some(prev_span) = object_fields.insert(field_str, *name) {
                         let err = ErrorKind::RepeatedField;
-                        return Err(Error::new(self.module_id.as_ref(), name, err)
+                        return Err(Error::new(self.module_id.clone(), name, err)
                             .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
                     }
                 }
@@ -160,7 +160,7 @@ impl<'a> CapturesExtractor<'a> {
                 self.eval(rhs)?;
                 let mut new_vars = HashMap::new();
                 extract_vars_iter(
-                    self.module_id.as_ref(),
+                    &self.module_id,
                     &mut new_vars,
                     iter::once(lhs),
                     RepeatedAssignmentContext::Assignment,
@@ -198,7 +198,7 @@ impl<'a> CapturesExtractor<'a> {
 }
 
 fn extract_vars<'a, T>(
-    module_id: &dyn ModuleId,
+    module_id: &Arc<dyn ModuleId>,
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     lvalues: &Destructure<'a, T>,
     context: RepeatedAssignmentContext,
@@ -216,7 +216,7 @@ fn extract_vars<'a, T>(
 }
 
 fn add_var<'a>(
-    module_id: &dyn ModuleId,
+    module_id: &Arc<dyn ModuleId>,
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     var_span: Spanned<'a>,
     context: RepeatedAssignmentContext,
@@ -225,7 +225,7 @@ fn add_var<'a>(
     if var_name != "_" {
         if let Some(prev_span) = vars.insert(var_name, var_span) {
             let err = ErrorKind::RepeatedAssignment { context };
-            return Err(Error::new(module_id, &var_span, err)
+            return Err(Error::new(module_id.clone(), &var_span, err)
                 .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
         }
     }
@@ -233,7 +233,7 @@ fn add_var<'a>(
 }
 
 pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
-    module_id: &dyn ModuleId,
+    module_id: &Arc<dyn ModuleId>,
     vars: &mut HashMap<&'a str, Spanned<'a>>,
     lvalues: impl Iterator<Item = &'it SpannedLvalue<'a, T>>,
     context: RepeatedAssignmentContext,
@@ -254,7 +254,7 @@ pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
                     let field_str = *field.field_name.fragment();
                     if let Some(prev_span) = object_fields.insert(field_str, field.field_name) {
                         let err = ErrorKind::RepeatedField;
-                        return Err(Error::new(module_id, &field.field_name, err)
+                        return Err(Error::new(module_id.clone(), &field.field_name, err)
                             .with_location(&prev_span.into(), AuxErrorInfo::PrevAssignment));
                     }
 
@@ -268,7 +268,7 @@ pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
 
             _ => {
                 let err = ErrorKind::unsupported(lvalue.extra.ty());
-                return Err(Error::new(module_id, lvalue, err));
+                return Err(Error::new(module_id.clone(), lvalue, err));
             }
         }
     }
@@ -284,13 +284,11 @@ pub(super) enum CompilerExtTarget<'r, 'a, T: Grammar<'a>> {
 
 impl<'a, T: Grammar<'a>> CompilerExtTarget<'_, 'a, T> {
     pub fn get_undefined_variables(self) -> Result<HashMap<&'a str, Spanned<'a>>, Error> {
-        let mut extractor = CapturesExtractor::new(Box::new(WildcardId));
-
+        let mut extractor = CapturesExtractor::new(Arc::new(WildcardId));
         match self {
             Self::Block(block) => extractor.eval_block_inner(block, HashMap::new())?,
             Self::FnDefinition(definition) => extractor.eval_function(definition)?,
         }
-
         Ok(extractor.captures)
     }
 }

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -3,7 +3,7 @@
 use core::iter;
 
 use crate::{
-    alloc::{vec, Arc, HashMap, ToOwned, Vec},
+    alloc::{vec, Arc, HashMap, String, ToOwned, Vec},
     error::{AuxErrorInfo, Error, ErrorKind, RepeatedAssignmentContext},
     exec::{ModuleId, WildcardId},
 };

--- a/eval/src/compiler/expr.rs
+++ b/eval/src/compiler/expr.rs
@@ -308,9 +308,7 @@ impl Compiler {
         def_expr: &SpannedExpr<'a, T>,
         def: &FnDefinition<'a, T>,
     ) -> Result<Atom<T::Lit>, Error> {
-        let module_id = self.module_id.clone_boxed();
-
-        let mut extractor = CapturesExtractor::new(module_id);
+        let mut extractor = CapturesExtractor::new(self.module_id.clone());
         extractor.eval_function(def)?;
         let captures = self.get_captures(extractor);
 
@@ -359,7 +357,7 @@ impl Compiler {
         captures: &HashMap<&'a str, LocatedAtom<T::Lit>>,
     ) -> Result<Executable<T::Lit>, Error> {
         // Allocate registers for captures.
-        let mut this = Self::new(self.module_id.clone_boxed());
+        let mut this = Self::new(self.module_id.clone());
         this.scope_depth = 1; // Disable generating variable annotations.
 
         for (i, &name) in captures.keys().enumerate() {
@@ -367,7 +365,7 @@ impl Compiler {
         }
         this.register_count = captures.len() + 1; // one additional register for args
 
-        let mut executable = Executable::new(self.module_id.clone_boxed());
+        let mut executable = Executable::new(self.module_id.clone());
         let args_span = def.args.with_no_extra();
         this.destructure(&mut executable, &def.args.extra, args_span, captures.len())?;
 
@@ -395,7 +393,7 @@ impl Compiler {
 
             Statement::Assignment { lhs, rhs } => {
                 extract_vars_iter(
-                    self.module_id.as_ref(),
+                    &self.module_id,
                     &mut HashMap::new(),
                     iter::once(lhs),
                     RepeatedAssignmentContext::Assignment,

--- a/eval/src/compiler/mod.rs
+++ b/eval/src/compiler/mod.rs
@@ -1,23 +1,20 @@
 //! Transformation of AST output by the parser into non-recursive format.
 
 use crate::{
-    alloc::{Arc, HashMap, String, ToOwned, Vec},
-    exec::{
-        Atom, Command, CompiledExpr, Executable, ExecutableModule, FieldName, ModuleId, Registers,
-    },
-    Error, ErrorKind, Value,
+    alloc::{Arc, HashMap, String, ToOwned},
+    exec::{Atom, Command, CompiledExpr, Executable, ExecutableModule, FieldName, ModuleId},
+    Error, ErrorKind,
 };
 use arithmetic_parser::{
-    grammars::Grammar, BinaryOp, Block, Destructure, FnDefinition, InputSpan, Location, Lvalue,
+    grammars::Grammar, BinaryOp, Block, Destructure, FnDefinition, InputSpan, Lvalue,
     ObjectDestructure, Spanned, SpannedLvalue, UnaryOp,
 };
 
 mod captures;
 mod expr;
 
+pub(crate) use self::captures::Captures;
 use self::captures::{CapturesExtractor, CompilerExtTarget};
-
-pub(crate) type ImportLocations = Vec<Location>;
 
 #[derive(Debug)]
 pub(crate) struct Compiler {
@@ -38,10 +35,10 @@ impl Compiler {
         }
     }
 
-    fn from_env<T>(module_id: Arc<dyn ModuleId>, env: &Registers<T>) -> Self {
+    fn from_env(module_id: Arc<dyn ModuleId>, env: &Captures) -> Self {
         Self {
             vars_to_registers: env.variables_map().clone(),
-            register_count: env.register_count(),
+            register_count: env.len(),
             scope_depth: 0,
             module_id,
         }
@@ -113,7 +110,7 @@ impl Compiler {
         block: &Block<'a, T>,
     ) -> Result<ExecutableModule<T::Lit>, Error> {
         let module_id = Arc::new(module_id) as Arc<dyn ModuleId>;
-        let (captures, import_spans) = Self::extract_captures(module_id.clone(), block)?;
+        let captures = Self::extract_captures(module_id.clone(), block)?;
         let mut compiler = Self::from_env(module_id.clone(), &captures);
 
         let mut executable = Executable::new(module_id);
@@ -129,32 +126,16 @@ impl Compiler {
         );
 
         executable.finalize_block(compiler.register_count);
-        Ok(ExecutableModule::from_parts(
-            executable,
-            captures,
-            import_spans,
-        ))
+        Ok(ExecutableModule::from_parts(executable, captures))
     }
 
     fn extract_captures<'a, T: Grammar<'a>>(
         module_id: Arc<dyn ModuleId>,
         block: &Block<'a, T>,
-    ) -> Result<(Registers<T::Lit>, ImportLocations), Error> {
+    ) -> Result<Captures, Error> {
         let mut extractor = CapturesExtractor::new(module_id);
         extractor.eval_block(block)?;
-
-        let mut captures = Registers::new();
-        for &var_name in extractor.captures.keys() {
-            captures.insert_var(var_name, Value::void());
-        }
-
-        let import_spans = extractor
-            .captures
-            .into_iter()
-            .map(|(_, var_span)| var_span.into())
-            .collect();
-
-        Ok((captures, import_spans))
+        Ok(extractor.into_captures())
     }
 
     fn assign<T, Ty>(
@@ -320,11 +301,13 @@ impl<'a, T: Grammar<'a>> CompilerExt<'a> for FnDefinition<'a, T> {
 
 #[cfg(test)]
 mod tests {
+    use arithmetic_parser::{
+        grammars::{F32Grammar, Parse, ParseLiteral, Typed, Untyped},
+        Expr, Location, NomResult,
+    };
+
     use super::*;
     use crate::{exec::WildcardId, Environment, Value};
-
-    use arithmetic_parser::grammars::{F32Grammar, Parse, ParseLiteral, Typed, Untyped};
-    use arithmetic_parser::{Expr, NomResult};
 
     #[test]
     fn compilation_basics() {
@@ -389,13 +372,11 @@ mod tests {
     fn extracting_captures() {
         let program = "y = 5 * x; y - 3 + x";
         let module = Untyped::<F32Grammar>::parse_statements(program).unwrap();
-        let (registers, import_spans) =
-            Compiler::extract_captures(Arc::new(WildcardId), &module).unwrap();
+        let captures = Compiler::extract_captures(Arc::new(WildcardId), &module).unwrap();
 
-        assert_eq!(registers.register_count(), 1);
-        assert!(registers.variables_map().contains_key("x"));
-        assert_eq!(import_spans.len(), 1);
-        assert_eq!(import_spans[0], Location::from_str(program, 8..9));
+        let captures: Vec<_> = captures.iter().collect();
+        assert_eq!(captures.len(), 1);
+        assert_eq!(captures[0], ("x", &Location::from_str(program, 8..9)));
     }
 
     #[test]
@@ -408,13 +389,12 @@ mod tests {
         "#;
         let module = Untyped::<F32Grammar>::parse_statements(program).unwrap();
 
-        let (registers, import_spans) =
-            Compiler::extract_captures(Arc::new(WildcardId), &module).unwrap();
-        assert_eq!(registers.register_count(), 2);
+        let captures = Compiler::extract_captures(Arc::new(WildcardId), &module).unwrap();
+        assert_eq!(captures.len(), 2);
 
-        assert!(registers.variables_map().contains_key("PI"));
-        let x_register = registers.variables_map()["x"];
-        assert_eq!(import_spans[x_register].location_line(), 2); // should be the first mention
+        assert!(captures.contains("PI"));
+        let x_location = captures.location("x").unwrap();
+        assert_eq!(x_location.location_line(), 2); // should be the first mention
     }
 
     #[test]

--- a/eval/src/env/mod.rs
+++ b/eval/src/env/mod.rs
@@ -6,7 +6,7 @@ mod variable_map;
 pub use self::variable_map::{Assertions, Comparisons, Prelude};
 
 use crate::{
-    alloc::{hash_map, HashMap, Rc, String, ToOwned},
+    alloc::{hash_map, Arc, HashMap, String, ToOwned},
     arith::{OrdArithmetic, StdArithmetic},
     exec::Operations,
     fns, NativeFn, Value,
@@ -45,7 +45,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Environment<T> {
     variables: HashMap<String, Value<T>>,
-    arithmetic: Rc<dyn OrdArithmetic<T>>,
+    arithmetic: Arc<dyn OrdArithmetic<T>>,
 }
 
 impl<T> Default for Environment<T>
@@ -72,7 +72,7 @@ where
     pub fn new() -> Self {
         Self {
             variables: HashMap::new(),
-            arithmetic: Rc::new(StdArithmetic),
+            arithmetic: Arc::new(StdArithmetic),
         }
     }
 }
@@ -85,7 +85,7 @@ impl<T> Environment<T> {
     {
         Self {
             variables: HashMap::new(),
-            arithmetic: Rc::new(arithmetic),
+            arithmetic: Arc::new(arithmetic),
         }
     }
 

--- a/eval/src/env/mod.rs
+++ b/eval/src/env/mod.rs
@@ -132,11 +132,15 @@ impl<T> Environment<T> {
     /// the Rust compiler will usually be able to extract the `Args` type param
     /// from the function definition, provided that type of function arguments and its return type
     /// are defined explicitly or can be unequivocally inferred from the declaration.
-    pub fn insert_wrapped_fn<Args, F>(&mut self, name: &str, fn_to_wrap: F) -> &mut Self
+    pub fn insert_wrapped_fn<const CTX: bool, Args, F>(
+        &mut self,
+        name: &str,
+        fn_to_wrap: F,
+    ) -> &mut Self
     where
-        fns::FnWrapper<Args, F>: NativeFn<T> + 'static,
+        fns::FnWrapper<Args, F, CTX>: NativeFn<T> + 'static,
     {
-        let wrapped = fns::wrap::<Args, _>(fn_to_wrap);
+        let wrapped = fns::wrap::<CTX, Args, _>(fn_to_wrap);
         self.insert(name, Value::native_fn(wrapped))
     }
 }

--- a/eval/src/exec/mod.rs
+++ b/eval/src/exec/mod.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 
 use crate::{
+    alloc::Arc,
     compiler::{Compiler, ImportLocations},
     env::Environment,
     error::{Backtrace, Error, ErrorKind, ErrorWithBacktrace},
@@ -161,7 +162,7 @@ impl<T> ExecutableModule<T> {
     }
 
     /// Gets the identifier of this module.
-    pub fn id(&self) -> &dyn ModuleId {
+    pub fn id(&self) -> &Arc<dyn ModuleId> {
         self.inner.id()
     }
 
@@ -196,7 +197,7 @@ impl<T> ExecutableModule<T> {
         for (name, span) in self.imports.iter() {
             if !env.contains(name) {
                 let err = ErrorKind::Undefined(name.into());
-                return Err(Error::new(self.inner.id(), span, err));
+                return Err(Error::new(self.inner.id().clone(), span, err));
             }
         }
         Ok(())

--- a/eval/src/exec/module_id.rs
+++ b/eval/src/exec/module_id.rs
@@ -5,8 +5,6 @@ use core::{
     fmt,
 };
 
-use crate::alloc::Box;
-
 /// Identifier of an [`ExecutableModule`](crate::ExecutableModule). This is usually a "small" type,
 /// such as an integer or a string.
 ///
@@ -19,12 +17,7 @@ use crate::alloc::Box;
 ///
 /// [`InterpretedFn`]: crate::InterpretedFn
 /// [`LocationInModule`]: crate::error::LocationInModule
-pub trait ModuleId: Any + fmt::Display + Send + Sync {
-    /// Clones this module ID and boxes the result. It is expected that the output will have
-    /// the same specific type as the original module ID. This operation is generally expected
-    /// to be quite cheap.
-    fn clone_boxed(&self) -> Box<dyn ModuleId>;
-}
+pub trait ModuleId: Any + fmt::Display + Send + Sync {}
 
 impl dyn ModuleId {
     /// Returns `true` if the boxed type is the same as `T`.
@@ -64,11 +57,7 @@ impl fmt::Debug for dyn ModuleId {
     }
 }
 
-impl ModuleId for &'static str {
-    fn clone_boxed(&self) -> Box<dyn ModuleId> {
-        Box::new(*self)
-    }
-}
+impl ModuleId for &'static str {}
 
 /// Module identifier that has a single possible value, which is displayed as `*`.
 ///
@@ -77,11 +66,7 @@ impl ModuleId for &'static str {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WildcardId;
 
-impl ModuleId for WildcardId {
-    fn clone_boxed(&self) -> Box<dyn ModuleId> {
-        Box::new(*self)
-    }
-}
+impl ModuleId for WildcardId {}
 
 impl fmt::Display for WildcardId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -119,8 +104,4 @@ impl fmt::Display for IndexedId {
     }
 }
 
-impl ModuleId for IndexedId {
-    fn clone_boxed(&self) -> Box<dyn ModuleId> {
-        Box::new(*self)
-    }
-}
+impl ModuleId for IndexedId {}

--- a/eval/src/exec/registers.rs
+++ b/eval/src/exec/registers.rs
@@ -1,7 +1,7 @@
 //! `Registers` for executing commands and closely related types.
 
 use crate::{
-    alloc::{vec, Arc, HashMap, Rc, String, ToOwned, Vec},
+    alloc::{vec, Arc, HashMap, String, ToOwned, Vec},
     arith::OrdArithmetic,
     error::{Backtrace, EvalResult, LocationInModule, TupleLenMismatchContext},
     exec::command::{Atom, Command, CompiledExpr, FieldName, LocatedAtom, LocatedCommand},
@@ -15,7 +15,7 @@ use arithmetic_parser::{BinaryOp, Location, LvalueLen, UnaryOp};
 pub(crate) struct Executable<T> {
     id: Arc<dyn ModuleId>,
     commands: Vec<LocatedCommand<T>>,
-    child_fns: Vec<Rc<ExecutableFn<T>>>,
+    child_fns: Vec<Arc<ExecutableFn<T>>>,
     // Hint how many registers the executable requires.
     register_capacity: usize,
 }
@@ -44,7 +44,7 @@ impl<T> Executable<T> {
 
     pub fn push_child_fn(&mut self, child_fn: ExecutableFn<T>) -> usize {
         let fn_ptr = self.child_fns.len();
-        self.child_fns.push(Rc::new(child_fn));
+        self.child_fns.push(Arc::new(child_fn));
         fn_ptr
     }
 
@@ -368,7 +368,7 @@ impl<T: 'static + Clone> Registers<T> {
                 captures,
                 capture_names,
             } => {
-                let fn_executable = Rc::clone(&executable.child_fns[*ptr]);
+                let fn_executable = Arc::clone(&executable.child_fns[*ptr]);
                 let captured_values = captures
                     .iter()
                     .map(|capture| self.resolve_atom(&capture.extra))

--- a/eval/src/exec/registers.rs
+++ b/eval/src/exec/registers.rs
@@ -3,6 +3,7 @@
 use crate::{
     alloc::{vec, Arc, HashMap, String, ToOwned, Vec},
     arith::OrdArithmetic,
+    compiler::Captures,
     error::{Backtrace, EvalResult, LocationInModule, TupleLenMismatchContext},
     exec::command::{Atom, Command, CompiledExpr, FieldName, LocatedAtom, LocatedCommand},
     exec::ModuleId,
@@ -133,31 +134,14 @@ impl<T> Registers<T> {
             inner_scope_start: None,
         }
     }
+}
 
-    pub fn variables(&self) -> impl Iterator<Item = (&str, &Value<T>)> + '_ {
-        self.vars
-            .iter()
-            .map(move |(name, register)| (name.as_str(), &self.registers[*register]))
-    }
-
-    pub fn variables_map(&self) -> &HashMap<String, usize> {
-        &self.vars
-    }
-
-    pub fn register_count(&self) -> usize {
-        self.registers.len()
-    }
-
-    /// Allocates a new register with the specified name if the name was not allocated previously.
-    pub fn insert_var(&mut self, name: &str, value: Value<T>) -> bool {
-        if self.vars.contains_key(name) {
-            false
-        } else {
-            let register = self.registers.len();
-            self.registers.push(value);
-            self.vars.insert(name.to_owned(), register);
-
-            true
+impl<T> From<&Captures> for Registers<T> {
+    fn from(captures: &Captures) -> Self {
+        Self {
+            registers: (0..captures.len()).map(|_| Value::void()).collect(),
+            vars: captures.variables_map().clone(),
+            inner_scope_start: None,
         }
     }
 }

--- a/eval/src/fns/assertions.rs
+++ b/eval/src/fns/assertions.rs
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn assert_basics() {
         let env = Environment::with_arithmetic(<CheckedArithmetic>::new());
-        let mut ctx = CallContext::<u32>::mock(&WildcardId, Location::from_str("", ..), &env);
+        let mut ctx = CallContext::<u32>::mock(WildcardId, Location::from_str("", ..), &env);
 
         let err = Assert.evaluate(vec![], &mut ctx).unwrap_err();
         assert_matches!(err.kind(), ErrorKind::ArgsLenMismatch { .. });
@@ -413,7 +413,7 @@ mod tests {
     #[test]
     fn assert_eq_basics() {
         let env = Environment::with_arithmetic(<CheckedArithmetic>::new());
-        let mut ctx = CallContext::<u32>::mock(&WildcardId, Location::from_str("", ..), &env);
+        let mut ctx = CallContext::<u32>::mock(WildcardId, Location::from_str("", ..), &env);
 
         let err = AssertEq.evaluate(vec![], &mut ctx).unwrap_err();
         assert_matches!(err.kind(), ErrorKind::ArgsLenMismatch { .. });
@@ -434,7 +434,7 @@ mod tests {
     fn assert_close_basics() {
         let assert_close = AssertClose::new(1e-3);
         let env = Environment::new();
-        let mut ctx = CallContext::<f32>::mock(&WildcardId, Location::from_str("", ..), &env);
+        let mut ctx = CallContext::<f32>::mock(WildcardId, Location::from_str("", ..), &env);
 
         let err = assert_close.evaluate(vec![], &mut ctx).unwrap_err();
         assert_matches!(err.kind(), ErrorKind::ArgsLenMismatch { .. });
@@ -490,7 +490,7 @@ mod tests {
     fn assert_fails_basics() {
         let assert_fails = AssertFails::default();
         let env = Environment::new();
-        let mut ctx = CallContext::<f32>::mock(&WildcardId, Location::from_str("", ..), &env);
+        let mut ctx = CallContext::<f32>::mock(WildcardId, Location::from_str("", ..), &env);
 
         let err = assert_fails.evaluate(vec![], &mut ctx).unwrap_err();
         assert_matches!(err.kind(), ErrorKind::ArgsLenMismatch { .. });
@@ -526,7 +526,7 @@ mod tests {
             |err| matches!(err.kind(), ErrorKind::NativeCall(msg) if msg == "oops"),
         );
         let env = Environment::new();
-        let mut ctx = CallContext::<f32>::mock(&WildcardId, Location::from_str("", ..), &env);
+        let mut ctx = CallContext::<f32>::mock(WildcardId, Location::from_str("", ..), &env);
 
         let wrong_fn = Value::wrapped_fn(f32::abs);
         let err = assert_fails

--- a/eval/src/fns/mod.rs
+++ b/eval/src/fns/mod.rs
@@ -7,20 +7,7 @@
 //! - Implement [`NativeFn`] manually. This is the most versatile approach, but it can be overly
 //!   verbose.
 //! - Use [`FnWrapper`] or the [`wrap`] function. This allows specifying arguments / output
-//!   with custom types (such as `bool` or a [`Number`]), but does not work for non-`'static`
-//!   types.
-//! - Use [`wrap_fn`](crate::wrap_fn) or [`wrap_fn_with_context`](crate::wrap_fn_with_context)
-//!   macros. These macros support
-//!   the same eloquent interface as `wrap`, and also do not have `'static` requirement for args.
-//!   As a downside, debugging compile-time errors when using macros can be rather painful.
-//!
-//! ## Why multiple ways to do the same thing?
-//!
-//! In the ideal world, `FnWrapper` would be used for all cases, since it does not involve
-//! macro magic. Unfortunately, Rust currently does not provide means to describe
-//! lifetime restrictions on args / return type of wrapped functions in the general case.
-//! As such, the implicit `'static` requirement is a temporary measure, and macros fill the gaps
-//! in their usual clunky manner.
+//!   with custom types (such as `bool` or a [`Number`]).
 //!
 //! [`Number`]: crate::Number
 

--- a/eval/src/fns/mod.rs
+++ b/eval/src/fns/mod.rs
@@ -48,9 +48,8 @@ pub use self::{
     assertions::{Assert, AssertClose, AssertEq, AssertFails},
     flow::{If, While},
     wrapper::{
-        enforce_closure_type, wrap, Binary, ErrorOutput, FnWrapper, FromValueError,
-        FromValueErrorKind, FromValueErrorLocation, IntoEvalResult, Quaternary, Ternary,
-        TryFromValue, Unary,
+        wrap, Binary, ErrorOutput, FnWrapper, FromValueError, FromValueErrorKind,
+        FromValueErrorLocation, IntoEvalResult, Quaternary, Ternary, TryFromValue, Unary,
     },
 };
 

--- a/eval/src/fns/wrapper/mod.rs
+++ b/eval/src/fns/wrapper/mod.rs
@@ -17,7 +17,7 @@ pub use self::traits::{
 /// This is a slightly shorter way to create wrappers compared to calling [`FnWrapper::new()`].
 ///
 /// See [`FnWrapper`] for more details on function requirements.
-pub const fn wrap<T, F>(function: F) -> FnWrapper<T, F> {
+pub const fn wrap<const CTX: bool, T, F>(function: F) -> FnWrapper<T, F, CTX> {
     FnWrapper::new(function)
 }
 
@@ -28,9 +28,8 @@ pub const fn wrap<T, F>(function: F) -> FnWrapper<T, F> {
 /// via [`Environment::insert_wrapped_fn()`], [`Value::wrapped_fn()`], or [`wrap()`].
 ///
 /// Arguments of a wrapped function must implement [`TryFromValue`] trait for the applicable
-/// grammar, and the output type must implement [`IntoEvalResult`]. If arguments and/or output
-/// have non-`'static` lifetime, use the [`wrap_fn`] macro. If you need [`CallContext`] (e.g.,
-/// to call functions provided as an argument), use the [`wrap_fn_with_context`] macro.
+/// grammar, and the output type must implement [`IntoEvalResult`]. If you need [`CallContext`] (e.g.,
+/// to call functions provided as an argument), provide it as a first argument.
 ///
 /// [`Environment::insert_wrapped_fn()`]: crate::Environment::insert_wrapped_fn()
 /// [`wrap_fn`]: crate::wrap_fn
@@ -83,12 +82,14 @@ pub const fn wrap<T, F>(function: F) -> FnWrapper<T, F> {
 /// # Ok(())
 /// # }
 /// ```
-pub struct FnWrapper<T, F> {
+///
+/// FIXME: example with context
+pub struct FnWrapper<T, F, const CTX: bool = false> {
     function: F,
     _arg_types: PhantomData<T>,
 }
 
-impl<T, F> fmt::Debug for FnWrapper<T, F>
+impl<T, F, const CTX: bool> fmt::Debug for FnWrapper<T, F, CTX>
 where
     F: fmt::Debug,
 {
@@ -96,11 +97,12 @@ where
         formatter
             .debug_struct("FnWrapper")
             .field("function", &self.function)
+            .field("context", &CTX)
             .finish()
     }
 }
 
-impl<T, F: Clone> Clone for FnWrapper<T, F> {
+impl<T, F: Clone, const CTX: bool> Clone for FnWrapper<T, F, CTX> {
     fn clone(&self) -> Self {
         Self {
             function: self.function.clone(),
@@ -109,11 +111,11 @@ impl<T, F: Clone> Clone for FnWrapper<T, F> {
     }
 }
 
-impl<T, F: Copy> Copy for FnWrapper<T, F> {}
+impl<T, F: Copy, const CTX: bool> Copy for FnWrapper<T, F, CTX> {}
 
 // Ideally, we would want to constrain `T` and `F`, but this would make it impossible to declare
 // the constructor as `const fn`; see https://github.com/rust-lang/rust/issues/57563.
-impl<T, F> FnWrapper<T, F> {
+impl<T, F, const CTX: bool> FnWrapper<T, F, CTX> {
     /// Creates a new wrapper.
     ///
     /// Note that the created wrapper is not guaranteed to be usable as [`NativeFn`]. For this
@@ -129,10 +131,10 @@ impl<T, F> FnWrapper<T, F> {
 }
 
 macro_rules! arity_fn {
-    ($arity:tt => $($arg_name:ident : $t:ident),*) => {
-        impl<Num, F, Ret, $($t,)*> NativeFn<Num> for FnWrapper<(Ret, $($t,)*), F>
+    ($arity:tt, $with_ctx:tt $(, $ctx_name:ident : $ctx_t:ty)? => $($arg_name:ident : $t:ident),*) => {
+        impl<Num, F, Ret, $($t,)*> NativeFn<Num> for FnWrapper<(Ret, $($t,)*), F, $with_ctx>
         where
-            F: Fn($($t,)*) -> Ret,
+            F: Fn($($ctx_t,)? $($t,)*) -> Ret,
             $($t: TryFromValue<Num>,)*
             Ret: IntoEvalResult<Num>,
         {
@@ -157,24 +159,36 @@ macro_rules! arity_fn {
                     })?;
                 )*
 
-                let output = (self.function)($($arg_name,)*);
+                $(let $ctx_name = &mut *context;)?
+                let output = (self.function)($($ctx_name,)? $($arg_name,)*);
                 output.into_eval_result().map_err(|err| err.into_spanned(context))
             }
         }
     };
 }
 
-arity_fn!(0 =>);
-arity_fn!(1 => x0: T);
-arity_fn!(2 => x0: T, x1: U);
-arity_fn!(3 => x0: T, x1: U, x2: V);
-arity_fn!(4 => x0: T, x1: U, x2: V, x3: W);
-arity_fn!(5 => x0: T, x1: U, x2: V, x3: W, x4: X);
-arity_fn!(6 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y);
-arity_fn!(7 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z);
-arity_fn!(8 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A);
-arity_fn!(9 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B);
-arity_fn!(10 => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B, x9: C);
+arity_fn!(0, false =>);
+arity_fn!(0, true, ctx: &mut CallContext<'_, Num> =>);
+arity_fn!(1, false => x0: T);
+arity_fn!(1, true, ctx: &mut CallContext<'_, Num> => x0: T);
+arity_fn!(2, false => x0: T, x1: U);
+arity_fn!(2, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U);
+arity_fn!(3, false => x0: T, x1: U, x2: V);
+arity_fn!(3, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V);
+arity_fn!(4, false => x0: T, x1: U, x2: V, x3: W);
+arity_fn!(4, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W);
+arity_fn!(5, false => x0: T, x1: U, x2: V, x3: W, x4: X);
+arity_fn!(5, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X);
+arity_fn!(6, false => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y);
+arity_fn!(6, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y);
+arity_fn!(7, false => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z);
+arity_fn!(7, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z);
+arity_fn!(8, false => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A);
+arity_fn!(8, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A);
+arity_fn!(9, false => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B);
+arity_fn!(9, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B);
+arity_fn!(10, false => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B, x9: C);
+arity_fn!(10, true, ctx: &mut CallContext<'_, Num> => x0: T, x1: U, x2: V, x3: W, x4: X, x5: Y, x6: Z, x7: A, x8: B, x9: C);
 
 /// Unary function wrapper.
 pub type Unary<T> = FnWrapper<(T, T), fn(T) -> T>;
@@ -188,185 +202,6 @@ pub type Ternary<T> = FnWrapper<(T, T, T, T), fn(T, T, T) -> T>;
 /// Quaternary function wrapper.
 pub type Quaternary<T> = FnWrapper<(T, T, T, T, T), fn(T, T, T, T) -> T>;
 
-/// An alternative for [`wrap`] function which works for arguments / return results with
-/// non-`'static` lifetime.
-///
-/// The macro must be called with 2 arguments (in this order):
-///
-/// - Function arity (from 0 to 10 inclusive)
-/// - Function or closure with the specified number of arguments. Using a function is recommended;
-///   using a closure may lead to hard-to-debug type inference errors.
-///
-/// As with `wrap`, all function arguments must implement [`TryFromValue`] and the return result
-/// must implement [`IntoEvalResult`]. Unlike `wrap`, the arguments / return result do not
-/// need to have a `'static` lifetime; examples include [`Value`]s, [`Function`]s
-/// and [`EvalResult`]s. Lifetimes of all arguments and the return result must match.
-///
-/// [`Value`]: crate::Value
-/// [`Function`]: crate::Function
-///
-/// # Examples
-///
-/// ```
-/// # use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
-/// # use arithmetic_eval::{wrap_fn, Function, Environment, ExecutableModule, Value};
-/// fn is_function<T>(value: Value<T>) -> bool {
-///     value.is_function()
-/// }
-///
-/// # fn main() -> anyhow::Result<()> {
-/// let program = "is_function(is_function) && !is_function(1)";
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test", &program)?;
-///
-/// let mut env = Environment::new();
-///  env.insert_native_fn("is_function", wrap_fn!(1, is_function));
-/// assert_eq!(module.with_env(&env)?.run()?, Value::Bool(true));
-/// # Ok(())
-/// # }
-/// ```
-///
-/// Usage of lifetimes:
-///
-/// ```
-/// # use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
-/// # use arithmetic_eval::{
-/// #     wrap_fn, CallContext, Function, Environment, ExecutableModule, Value, env::Prelude,
-/// # };
-/// // Note that both `Value`s have the same lifetime due to elision.
-/// fn take_if<T>(value: Value<T>, condition: bool) -> Value<T> {
-///     if condition { value } else { Value::void() }
-/// }
-///
-/// # fn main() -> anyhow::Result<()> {
-/// let program = "take_if((1, 2), true) == (1, 2) && take_if((3, 4), false) != (3, 4)";
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test", &program)?;
-///
-/// let mut env = Environment::new();
-/// env.extend(Prelude::iter());
-/// env.insert_native_fn("take_if", wrap_fn!(2, take_if));
-/// assert_eq!(module.with_env(&env)?.run()?, Value::Bool(true));
-/// # Ok(())
-/// # }
-/// ```
-#[macro_export]
-macro_rules! wrap_fn {
-    (0, $function:expr) => { $crate::wrap_fn!(@arg 0 =>; $function) };
-    (1, $function:expr) => { $crate::wrap_fn!(@arg 1 => x0; $function) };
-    (2, $function:expr) => { $crate::wrap_fn!(@arg 2 => x0, x1; $function) };
-    (3, $function:expr) => { $crate::wrap_fn!(@arg 3 => x0, x1, x2; $function) };
-    (4, $function:expr) => { $crate::wrap_fn!(@arg 4 => x0, x1, x2, x3; $function) };
-    (5, $function:expr) => { $crate::wrap_fn!(@arg 5 => x0, x1, x2, x3, x4; $function) };
-    (6, $function:expr) => { $crate::wrap_fn!(@arg 6 => x0, x1, x2, x3, x4, x5; $function) };
-    (7, $function:expr) => { $crate::wrap_fn!(@arg 7 => x0, x1, x2, x3, x4, x5, x6; $function) };
-    (8, $function:expr) => {
-        $crate::wrap_fn!(@arg 8 => x0, x1, x2, x3, x4, x5, x6, x7; $function)
-    };
-    (9, $function:expr) => {
-        $crate::wrap_fn!(@arg 9 => x0, x1, x2, x3, x4, x5, x6, x7, x8; $function)
-    };
-    (10, $function:expr) => {
-        $crate::wrap_fn!(@arg 10 => x0, x1, x2, x3, x4, x5, x6, x7, x8, x9; $function)
-    };
-
-    ($($ctx:ident,)? @arg $arity:expr => $($arg_name:ident),*; $function:expr) => {{
-        let function = $function;
-        $crate::fns::enforce_closure_type(move |args, context| {
-            context.check_args_count(&args, $arity)?;
-            let mut args_iter = args.into_iter().enumerate();
-
-            $(
-                let (index, $arg_name) = args_iter.next().unwrap();
-                let span = $arg_name.with_no_extra();
-                let $arg_name = $crate::fns::TryFromValue::try_from_value($arg_name.extra)
-                    .map_err(|mut err| {
-                        err.set_arg_index(index);
-                        context
-                            .call_site_error($crate::error::ErrorKind::Wrapper(err))
-                            .with_location(&span, $crate::error::AuxErrorInfo::InvalidArg)
-                    })?;
-            )+
-
-            // We need `$ctx` just as a marker that the function receives a context.
-            let output = function($({ let $ctx = (); context },)? $($arg_name,)+);
-            $crate::fns::IntoEvalResult::into_eval_result(output)
-                .map_err(|err| err.into_spanned(context))
-        })
-    }}
-}
-
-/// Analogue of [`wrap_fn`](crate::wrap_fn) macro that injects the [`CallContext`]
-/// as the first argument. This can be used to call functions within the implementation.
-///
-/// As with `wrap_fn`, this macro must be called with 2 args: the arity of the function
-/// (**excluding** `CallContext`), and then the function / closure itself.
-///
-/// # Examples
-///
-/// ```
-/// # use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
-/// # use arithmetic_eval::{
-/// #     wrap_fn_with_context, CallContext, Function, Environment, Value, ExecutableModule, Error,
-/// # };
-/// fn map_array(
-///     context: &mut CallContext<'_, f32>,
-///     array: Vec<Value<f32>>,
-///     map_fn: Function<f32>,
-/// ) -> Result<Vec<Value<f32>>, Error> {
-///     array
-///         .into_iter()
-///         .map(|value| {
-///             let arg = context.apply_call_location(value);
-///             map_fn.evaluate(vec![arg], context)
-///         })
-///         .collect()
-/// }
-///
-/// # fn main() -> anyhow::Result<()> {
-/// let program = "map((1, 2, 3), |x| x + 3) == (4, 5, 6)";
-/// let program = Untyped::<F32Grammar>::parse_statements(program)?;
-/// let module = ExecutableModule::new("test", &program)?;
-///
-/// let mut env = Environment::new();
-/// env.insert_native_fn("map", wrap_fn_with_context!(2, map_array));
-/// assert_eq!(module.with_env(&env)?.run()?, Value::Bool(true));
-/// # Ok(())
-/// # }
-/// ```
-#[macro_export]
-macro_rules! wrap_fn_with_context {
-    (0, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 0 =>; $function) };
-    (1, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 1 => x0; $function) };
-    (2, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 2 => x0, x1; $function) };
-    (3, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 3 => x0, x1, x2; $function) };
-    (4, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 4 => x0, x1, x2, x3; $function) };
-    (5, $function:expr) => { $crate::wrap_fn!(_ctx, @arg 5 => x0, x1, x2, x3, x4; $function) };
-    (6, $function:expr) => {
-        $crate::wrap_fn!(_ctx, @arg 6 => x0, x1, x2, x3, x4, x5; $function)
-    };
-    (7, $function:expr) => {
-        $crate::wrap_fn!(_ctx, @arg 7 => x0, x1, x2, x3, x4, x5, x6; $function)
-    };
-    (8, $function:expr) => {
-        $crate::wrap_fn!(_ctx, @arg 8 => x0, x1, x2, x3, x4, x5, x6, x7; $function)
-    };
-    (9, $function:expr) => {
-        $crate::wrap_fn!(_ctx, @arg 9 => x0, x1, x2, x3, x4, x5, x6, x7, x8; $function)
-    };
-    (10, $function:expr) => {
-        $crate::wrap_fn!(_ctx, @arg 10 => x0, x1, x2, x3, x4, x5, x6, x7, x8, x9; $function)
-    };
-}
-
-#[doc(hidden)] // necessary for `wrap_fn` macro
-pub fn enforce_closure_type<T, A, F>(function: F) -> F
-where
-    F: Fn(Vec<SpannedValue<T>>, &mut CallContext<'_, A>) -> EvalResult<T>,
-{
-    function
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -374,7 +209,7 @@ mod tests {
         alloc::{format, ToOwned},
         env::{Environment, Prelude},
         exec::{ExecutableModule, WildcardId},
-        Object, Tuple, Value,
+        Function, Object, Tuple, Value,
     };
 
     use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
@@ -557,7 +392,7 @@ mod tests {
         let block = Untyped::<F32Grammar>::parse_statements(program)?;
         let module = ExecutableModule::new(WildcardId, &block)?;
 
-        let test_function = Value::native_fn(wrap_fn!(1, test_function));
+        let test_function = Value::native_fn(wrap(test_function));
         let mut env = Environment::new();
         env.insert("test", test_function).extend(Prelude::iter());
 
@@ -584,6 +419,28 @@ mod tests {
         let err_message = err.source().kind().to_short_string();
         assert!(err_message.contains("Cannot convert primitive value to bool"));
         assert!(err_message.contains("location: arg0[1].0"));
+        Ok(())
+    }
+
+    #[test]
+    fn function_with_context() -> anyhow::Result<()> {
+        #[allow(clippy::needless_pass_by_value)] // required for wrapping to work
+        fn call(
+            ctx: &mut CallContext<'_, f32>,
+            func: Function<f32>,
+            value: f32,
+        ) -> EvalResult<f32> {
+            let args = vec![ctx.apply_call_location(Value::Prim(value))];
+            func.evaluate(args, ctx)
+        }
+
+        let program = "(|x| { x + 1 }).call(1)";
+        let block = Untyped::<F32Grammar>::parse_statements(program)?;
+        let module = ExecutableModule::new(WildcardId, &block)?;
+
+        let mut env = Environment::new();
+        env.insert_wrapped_fn("call", call);
+        assert_eq!(module.with_env(&env)?.run()?, Value::Prim(2.0));
         Ok(())
     }
 }

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -218,8 +218,9 @@ mod alloc {
         borrow::ToOwned,
         boxed::Box,
         format,
-        rc::Rc,
+        rc::Rc, // FIXME: replace with `Arc` everywhere
         string::{String, ToString},
+        sync::Arc,
         vec,
         vec::Vec,
     };

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -218,7 +218,6 @@ mod alloc {
         borrow::ToOwned,
         boxed::Box,
         format,
-        rc::Rc, // FIXME: replace with `Arc` everywhere
         string::{String, ToString},
         sync::Arc,
         vec,

--- a/eval/src/values/function.rs
+++ b/eval/src/values/function.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 use crate::{
-    alloc::{Arc, HashMap, Rc, String, ToOwned, Vec},
+    alloc::{Arc, HashMap, String, ToOwned, Vec},
     arith::OrdArithmetic,
     error::{Backtrace, Error, ErrorKind, LocationInModule},
     exec::{ExecutableFn, ModuleId, Operations},
@@ -131,14 +131,14 @@ impl<T> dyn NativeFn<T> {
 /// Function defined within the interpreter.
 #[derive(Debug, Clone)]
 pub struct InterpretedFn<T> {
-    definition: Rc<ExecutableFn<T>>,
+    definition: Arc<ExecutableFn<T>>,
     captures: Vec<Value<T>>,
     capture_names: Vec<String>,
 }
 
 impl<T> InterpretedFn<T> {
     pub(crate) fn new(
-        definition: Rc<ExecutableFn<T>>,
+        definition: Arc<ExecutableFn<T>>,
         captures: Vec<Value<T>>,
         capture_names: Vec<String>,
     ) -> Self {
@@ -217,16 +217,16 @@ impl<T: 'static + Clone> InterpretedFn<T> {
 #[derive(Debug)]
 pub enum Function<T> {
     /// Native function.
-    Native(Rc<dyn NativeFn<T>>),
+    Native(Arc<dyn NativeFn<T>>),
     /// Interpreted function.
-    Interpreted(Rc<InterpretedFn<T>>),
+    Interpreted(Arc<InterpretedFn<T>>),
 }
 
 impl<T> Clone for Function<T> {
     fn clone(&self) -> Self {
         match self {
-            Self::Native(function) => Self::Native(Rc::clone(function)),
-            Self::Interpreted(function) => Self::Interpreted(Rc::clone(function)),
+            Self::Native(function) => Self::Native(Arc::clone(function)),
+            Self::Interpreted(function) => Self::Interpreted(Arc::clone(function)),
         }
     }
 }
@@ -257,14 +257,14 @@ impl<T: PartialEq> PartialEq for Function<T> {
 impl<T> Function<T> {
     /// Creates a native function.
     pub fn native(function: impl NativeFn<T> + 'static) -> Self {
-        Self::Native(Rc::new(function))
+        Self::Native(Arc::new(function))
     }
 
     /// Checks if the provided function is the same as this one.
     pub fn is_same_function(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Native(this), Self::Native(other)) => this.data_ptr() == other.data_ptr(),
-            (Self::Interpreted(this), Self::Interpreted(other)) => Rc::ptr_eq(this, other),
+            (Self::Interpreted(this), Self::Interpreted(other)) => Arc::ptr_eq(this, other),
             _ => false,
         }
     }

--- a/eval/src/values/mod.rs
+++ b/eval/src/values/mod.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use crate::{
-    alloc::{Rc, Vec},
+    alloc::{Arc, Vec},
     fns,
 };
 use arithmetic_parser::Location;
@@ -65,15 +65,16 @@ impl fmt::Display for ValueType {
 /// Opaque reference to a native value.
 ///
 /// The references cannot be created by interpreted code, but can be used as function args
-/// or return values of native functions. References are [`Rc`]'d, thus can easily be cloned.
+/// or return values of native functions. References are [`Arc`]'d, thus can easily be cloned.
 ///
 /// References are comparable among each other:
 ///
 /// - If the wrapped value implements [`PartialEq`], this implementation will be used
 ///   for comparison.
-/// - If `PartialEq` is not implemented, the comparison is by the `Rc` pointer.
+/// - If `PartialEq` is not implemented, the comparison is by the `Arc` pointer.
+#[derive(Clone)]
 pub struct OpaqueRef {
-    value: Rc<dyn Any>,
+    value: Arc<dyn Any>,
     type_name: &'static str,
     dyn_eq: fn(&dyn Any, &dyn Any) -> bool,
     dyn_fmt: fn(&dyn Any, &mut fmt::Formatter<'_>) -> fmt::Result,
@@ -89,7 +90,7 @@ impl OpaqueRef {
         T: Any + fmt::Debug + PartialEq,
     {
         Self {
-            value: Rc::new(value),
+            value: Arc::new(value),
             type_name: type_name::<T>(),
 
             dyn_eq: |this, other| {
@@ -112,7 +113,7 @@ impl OpaqueRef {
     #[allow(clippy::missing_panics_doc)] // false positive; `unwrap()`s never panic
     pub fn with_identity_eq<T: Any>(value: T) -> Self {
         Self {
-            value: Rc::new(value),
+            value: Arc::new(value),
             type_name: type_name::<T>(),
 
             dyn_eq: |this, other| {
@@ -127,17 +128,6 @@ impl OpaqueRef {
     /// Tries to downcast this reference to a specific type.
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.value.downcast_ref()
-    }
-}
-
-impl Clone for OpaqueRef {
-    fn clone(&self) -> Self {
-        Self {
-            value: Rc::clone(&self.value),
-            type_name: self.type_name,
-            dyn_eq: self.dyn_eq,
-            dyn_fmt: self.dyn_fmt,
-        }
     }
 }
 
@@ -191,7 +181,7 @@ pub type SpannedValue<T> = Location<Value<T>>;
 impl<T> Value<T> {
     /// Creates a value for a native function.
     pub fn native_fn(function: impl NativeFn<T> + 'static) -> Self {
-        Self::Function(Function::Native(Rc::new(function)))
+        Self::Function(Function::Native(Arc::new(function)))
     }
 
     /// Creates a [wrapped function](fns::FnWrapper).
@@ -211,7 +201,7 @@ impl<T> Value<T> {
 
     /// Creates a value for an interpreted function.
     pub(crate) fn interpreted_fn(function: InterpretedFn<T>) -> Self {
-        Self::Function(Function::Interpreted(Rc::new(function)))
+        Self::Function(Function::Interpreted(Arc::new(function)))
     }
 
     /// Creates a void value (an empty tuple).

--- a/eval/src/values/mod.rs
+++ b/eval/src/values/mod.rs
@@ -191,11 +191,11 @@ impl<T> Value<T> {
     /// will usually be able to extract the `Args` type param from the function definition,
     /// provided that type of function arguments and its return type are defined explicitly
     /// or can be unequivocally inferred from the declaration.
-    pub fn wrapped_fn<Args, F>(fn_to_wrap: F) -> Self
+    pub fn wrapped_fn<const CTX: bool, Args, F>(fn_to_wrap: F) -> Self
     where
-        fns::FnWrapper<Args, F>: NativeFn<T> + 'static,
+        fns::FnWrapper<Args, F, CTX>: NativeFn<T> + 'static,
     {
-        let wrapped = fns::wrap::<Args, _>(fn_to_wrap);
+        let wrapped = fns::wrap::<CTX, Args, _>(fn_to_wrap);
         Self::native_fn(wrapped)
     }
 

--- a/eval/tests/integration/hof.rs
+++ b/eval/tests/integration/hof.rs
@@ -1,8 +1,8 @@
 //! Demonstrates how to define high-order native functions.
 
 use arithmetic_eval::{
-    fns, wrap_fn, wrap_fn_with_context, CallContext, Environment, ErrorKind, EvalResult,
-    ExecutableModule, Function, NativeFn, SpannedValue, Value,
+    fns, CallContext, Environment, ErrorKind, EvalResult, ExecutableModule, Function, NativeFn,
+    SpannedValue, Value,
 };
 use arithmetic_parser::grammars::{F32Grammar, Parse, Untyped};
 
@@ -75,7 +75,7 @@ fn repeated_function() -> anyhow::Result<()> {
     let program = ExecutableModule::new("repeat", &program)?;
 
     let mut env = Environment::new();
-    env.insert_native_fn("repeat", wrap_fn!(2, repeat))
+    env.insert_wrapped_fn("repeat", repeat)
         .insert_native_fn("assert_eq", fns::AssertEq);
     program.with_env(&env)?.run()?;
     Ok(())
@@ -94,7 +94,7 @@ fn eager_repeated_function() -> anyhow::Result<()> {
     let program = ExecutableModule::new("repeat", &program)?;
 
     let mut env = Environment::new();
-    env.insert_native_fn("repeat", wrap_fn_with_context!(3, eager_repeat))
+    env.insert_wrapped_fn("repeat", eager_repeat)
         .insert_native_fn("assert_eq", fns::AssertEq);
     program.with_env(&env)?.run()?;
     Ok(())


### PR DESCRIPTION
## What?

Various chores after merging #121:

- Simplify function wrapping
- Simplify `ModuleId` trait
- Make `ExecutableModule` thread-safe.

## Why?

These are quality-of-life improvements that also improve maintainability.