### PR TITLE
Remove redundant lifetimes in parser crate

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -180,9 +180,9 @@ impl Reporter {
     }
 
     /// Reports a parsing error.
-    fn report_parse_error(&self, err: ParseError<'_>) -> io::Result<()> {
+    fn report_parse_error(&self, err: ParseError) -> io::Result<()> {
         // Parsing errors are always reported for the most recently added snippet.
-        let (file, range) = self.code_map.locate_in_most_recent_file(&err.span());
+        let (file, range) = self.code_map.locate_in_most_recent_file(&err.location());
 
         let label = Label::primary(file, range).with_message("Error occurred here");
         let diagnostic = Diagnostic::error()

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -575,9 +575,9 @@ impl<T: ReplLiteral> Env<T> {
         Ok(res.map(drop))
     }
 
-    fn compile_and_execute<'a, G>(&mut self, block: &Block<'a, G>) -> io::Result<ParseAndEvalResult>
+    fn compile_and_execute<G>(&mut self, block: &Block<'_, G>) -> io::Result<ParseAndEvalResult>
     where
-        G: Grammar<'a, Lit = T>,
+        G: Grammar<Lit = T>,
     {
         let module_id = self.reporter.code_map.latest_module_id();
         let module = ExecutableModule::new(module_id, block);

--- a/eval/examples/cyclic_group.rs
+++ b/eval/examples/cyclic_group.rs
@@ -284,7 +284,7 @@ const DSA_SIGNATURES: &str = include_str!("dsa.script");
 #[derive(Debug, Clone, Copy)]
 struct GroupGrammar;
 
-impl Parse<'_> for GroupGrammar {
+impl Parse for GroupGrammar {
     type Base = Untyped<NumGrammar<GroupLiteral>>;
 
     // Disable comparisons in the parser.

--- a/eval/examples/owned_module.rs
+++ b/eval/examples/owned_module.rs
@@ -8,7 +8,7 @@ use arithmetic_eval::{
 };
 use arithmetic_parser::{
     grammars::{F64Grammar, MockTypes, Parse, WithMockedTypes},
-    BinaryOp, Error as ParseError,
+    BinaryOp,
 };
 
 /// We need to process some type annotations, but don't want to depend
@@ -26,7 +26,7 @@ fn create_module(
     module_name: &'static str,
     program: &str,
 ) -> anyhow::Result<ExecutableModule<f64>> {
-    let block = Grammar::parse_statements(program).map_err(ParseError::strip_code)?;
+    let block = Grammar::parse_statements(program)?;
     Ok(ExecutableModule::new(module_name, &block)?)
 }
 

--- a/eval/src/compiler/captures.rs
+++ b/eval/src/compiler/captures.rs
@@ -61,7 +61,7 @@ impl<'a> CapturesExtractor<'a> {
     }
 
     /// Collects variables captured by the function into a single `Scope`.
-    pub fn eval_function<T: Grammar<'a>>(
+    pub fn eval_function<T: Grammar>(
         &mut self,
         definition: &FnDefinition<'a, T>,
     ) -> Result<(), Error> {
@@ -93,7 +93,7 @@ impl<'a> CapturesExtractor<'a> {
 
     /// Evaluates an expression with the function validation semantics, i.e., to determine
     /// function captures.
-    fn eval<T: Grammar<'a>>(&mut self, expr: &SpannedExpr<'a, T>) -> Result<(), Error> {
+    fn eval<T: Grammar>(&mut self, expr: &SpannedExpr<'a, T>) -> Result<(), Error> {
         match &expr.extra {
             Expr::Variable => {
                 self.eval_local_var(expr);
@@ -179,7 +179,7 @@ impl<'a> CapturesExtractor<'a> {
     }
 
     /// Evaluates a statement using the provided context.
-    fn eval_statement<T: Grammar<'a>>(
+    fn eval_statement<T: Grammar>(
         &mut self,
         statement: &SpannedStatement<'a, T>,
     ) -> Result<(), Error> {
@@ -206,7 +206,7 @@ impl<'a> CapturesExtractor<'a> {
         }
     }
 
-    fn eval_block_inner<T: Grammar<'a>>(
+    fn eval_block_inner<T: Grammar>(
         &mut self,
         block: &Block<'a, T>,
         local_vars: HashMap<&'a str, Spanned<'a>>,
@@ -222,7 +222,7 @@ impl<'a> CapturesExtractor<'a> {
         Ok(())
     }
 
-    pub fn eval_block<T: Grammar<'a>>(&mut self, block: &Block<'a, T>) -> Result<(), Error> {
+    pub fn eval_block<T: Grammar>(&mut self, block: &Block<'a, T>) -> Result<(), Error> {
         self.eval_block_inner(block, HashMap::new())
     }
 
@@ -317,12 +317,12 @@ pub(super) fn extract_vars_iter<'it, 'a: 'it, T: 'it>(
 
 /// Helper enum for `CompilerExt` implementations that allows to reduce code duplication.
 #[derive(Debug)]
-pub(super) enum CompilerExtTarget<'r, 'a, T: Grammar<'a>> {
+pub(super) enum CompilerExtTarget<'r, 'a, T: Grammar> {
     Block(&'r Block<'a, T>),
     FnDefinition(&'r FnDefinition<'a, T>),
 }
 
-impl<'a, T: Grammar<'a>> CompilerExtTarget<'_, 'a, T> {
+impl<'a, T: Grammar> CompilerExtTarget<'_, 'a, T> {
     pub fn get_undefined_variables(self) -> Result<HashMap<&'a str, Spanned<'a>>, Error> {
         let mut extractor = CapturesExtractor::new(Arc::new(WildcardId));
         match self {

--- a/eval/src/compiler/expr.rs
+++ b/eval/src/compiler/expr.rs
@@ -15,10 +15,10 @@ use arithmetic_parser::{
 };
 
 impl Compiler {
-    fn compile_expr<'a, T: Grammar<'a>>(
+    fn compile_expr<T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
-        expr: &SpannedExpr<'a, T>,
+        expr: &SpannedExpr<'_, T>,
     ) -> Result<LocatedAtom<T::Lit>, Error> {
         let atom = match &expr.extra {
             Expr::Literal(lit) => Atom::Constant(lit.clone()),
@@ -100,7 +100,7 @@ impl Compiler {
         Ok(Atom::Register(*register))
     }
 
-    fn compile_binary_expr<'a, T: Grammar<'a>>(
+    fn compile_binary_expr<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         binary_expr: &SpannedExpr<'a, T>,
@@ -121,7 +121,7 @@ impl Compiler {
         Ok(Atom::Register(register))
     }
 
-    fn compile_fn_call<'a, T: Grammar<'a>>(
+    fn compile_fn_call<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
@@ -139,7 +139,7 @@ impl Compiler {
         self.compile_fn_call_with_precompiled_name(executable, call_expr, name, original_name, args)
     }
 
-    fn compile_fn_call_with_precompiled_name<'a, T: Grammar<'a>>(
+    fn compile_fn_call_with_precompiled_name<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
@@ -160,7 +160,7 @@ impl Compiler {
         Ok(Atom::Register(register))
     }
 
-    fn compile_field_access<'a, T: Grammar<'a>>(
+    fn compile_field_access<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
@@ -186,7 +186,7 @@ impl Compiler {
         Ok(Atom::Register(register))
     }
 
-    fn compile_method_call<'a, T: Grammar<'a>>(
+    fn compile_method_call<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         call_expr: &SpannedExpr<'a, T>,
@@ -214,7 +214,7 @@ impl Compiler {
         Ok(Atom::Register(register))
     }
 
-    fn compile_block<'r, 'a: 'r, T: Grammar<'a>>(
+    fn compile_block<'r, 'a: 'r, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         block_expr: &SpannedExpr<'a, T>,
@@ -264,10 +264,10 @@ impl Compiler {
         })
     }
 
-    pub(super) fn compile_block_inner<'a, T: Grammar<'a>>(
+    pub(super) fn compile_block_inner<T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
-        block: &Block<'a, T>,
+        block: &Block<'_, T>,
     ) -> Result<Option<LocatedAtom<T::Lit>>, Error> {
         for statement in &block.statements {
             self.compile_statement(executable, statement)?;
@@ -281,7 +281,7 @@ impl Compiler {
     }
 
     #[allow(clippy::option_if_let_else)] // false positive
-    fn compile_object<'a, T: Grammar<'a>>(
+    fn compile_object<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         object_expr: &SpannedExpr<'a, T>,
@@ -302,7 +302,7 @@ impl Compiler {
         Ok(Atom::Register(register))
     }
 
-    fn compile_fn_definition<'a, T: Grammar<'a>>(
+    fn compile_fn_definition<'a, T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
         def_expr: &SpannedExpr<'a, T>,
@@ -351,7 +351,7 @@ impl Compiler {
             .collect()
     }
 
-    fn compile_function<'a, T: Grammar<'a>>(
+    fn compile_function<'a, T: Grammar>(
         &self,
         def: &FnDefinition<'a, T>,
         captures: &HashMap<&'a str, LocatedAtom<T::Lit>>,
@@ -383,10 +383,10 @@ impl Compiler {
         Ok(executable)
     }
 
-    fn compile_statement<'a, T: Grammar<'a>>(
+    fn compile_statement<T: Grammar>(
         &mut self,
         executable: &mut Executable<T::Lit>,
-        statement: &SpannedStatement<'a, T>,
+        statement: &SpannedStatement<'_, T>,
     ) -> Result<Option<LocatedAtom<T::Lit>>, Error> {
         Ok(match &statement.extra {
             Statement::Expr(expr) => Some(self.compile_expr(executable, expr)?),

--- a/eval/src/compiler/mod.rs
+++ b/eval/src/compiler/mod.rs
@@ -105,9 +105,9 @@ impl Compiler {
         register
     }
 
-    pub fn compile_module<'a, Id: ModuleId, T: Grammar<'a>>(
+    pub fn compile_module<Id: ModuleId, T: Grammar>(
         module_id: Id,
-        block: &Block<'a, T>,
+        block: &Block<'_, T>,
     ) -> Result<ExecutableModule<T::Lit>, Error> {
         let module_id = Arc::new(module_id) as Arc<dyn ModuleId>;
         let captures = Self::extract_captures(module_id.clone(), block)?;
@@ -129,9 +129,9 @@ impl Compiler {
         Ok(ExecutableModule::from_parts(executable, captures))
     }
 
-    fn extract_captures<'a, T: Grammar<'a>>(
+    fn extract_captures<T: Grammar>(
         module_id: Arc<dyn ModuleId>,
-        block: &Block<'a, T>,
+        block: &Block<'_, T>,
     ) -> Result<Captures, Error> {
         let mut extractor = CapturesExtractor::new(module_id);
         extractor.eval_block(block)?;
@@ -287,13 +287,13 @@ pub trait CompilerExt<'a> {
     fn undefined_variables(&self) -> Result<HashMap<&'a str, Spanned<'a>>, Error>;
 }
 
-impl<'a, T: Grammar<'a>> CompilerExt<'a> for Block<'a, T> {
+impl<'a, T: Grammar> CompilerExt<'a> for Block<'a, T> {
     fn undefined_variables(&self) -> Result<HashMap<&'a str, Spanned<'a>>, Error> {
         CompilerExtTarget::Block(self).get_undefined_variables()
     }
 }
 
-impl<'a, T: Grammar<'a>> CompilerExt<'a> for FnDefinition<'a, T> {
+impl<'a, T: Grammar> CompilerExt<'a> for FnDefinition<'a, T> {
     fn undefined_variables(&self) -> Result<HashMap<&'a str, Spanned<'a>>, Error> {
         CompilerExtTarget::FnDefinition(self).get_undefined_variables()
     }
@@ -409,10 +409,10 @@ mod tests {
             }
         }
 
-        impl Grammar<'_> for TypedGrammar {
-            type Type = ();
+        impl Grammar for TypedGrammar {
+            type Type<'a> = ();
 
-            fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+            fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
                 use nom::{bytes::complete::tag, combinator::map};
                 map(tag("Num"), drop)(input)
             }

--- a/eval/src/exec/mod.rs
+++ b/eval/src/exec/mod.rs
@@ -131,10 +131,10 @@ static_assertions::assert_impl_all!(ExecutableModule<f32>: Send, Sync);
 
 impl<T: Clone + fmt::Debug> ExecutableModule<T> {
     /// Creates a new module.
-    pub fn new<'a, G, Id>(id: Id, block: &Block<'a, G>) -> Result<Self, Error>
+    pub fn new<G, Id>(id: Id, block: &Block<'_, G>) -> Result<Self, Error>
     where
         Id: ModuleId,
-        G: Grammar<'a, Lit = T>,
+        G: Grammar<Lit = T>,
     {
         Compiler::compile_module(id, block)
     }

--- a/eval/src/values/mod.rs
+++ b/eval/src/values/mod.rs
@@ -1,7 +1,5 @@
 //! Values used by the interpreter.
 
-// TODO: consider removing lifetimes from `Value` (i.e., strip code spans immediately)
-
 use core::{
     any::{type_name, Any},
     fmt,

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -20,9 +20,13 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Remove `MaybeSpanned` type in favor of `Location`. (#121)
 
+- Change `Grammar` and `Parse` traits to use a generic associated `Type` instead of trait lifetimes. (#123)
+
 ### Removed
 
 - Remove `StripCode` and `StripResultExt` traits as obsolete. (#121)
+
+- Remove lifetime generic from `Error`. (#123)
 
 ## 0.3.0 - 2021-05-24
 

--- a/parser/src/ast/expr.rs
+++ b/parser/src/ast/expr.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Arithmetic expression with an abstract types for type annotations and literals.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum Expr<'a, T: Grammar<'a>> {
+pub enum Expr<'a, T: Grammar> {
     /// Variable use, e.g., `x`.
     Variable,
     /// Literal (semantic depends on `T`).
@@ -25,7 +25,7 @@ pub enum Expr<'a, T: Grammar<'a>> {
         /// Value being cast, e.g., `x` in `x as Bool`.
         value: Box<SpannedExpr<'a, T>>,
         /// Type annotation for the case, e.g., `Bool` in `x as Bool`.
-        ty: Spanned<'a, T::Type>,
+        ty: Spanned<'a, T::Type<'a>>,
     },
     /// Function call, e.g., `foo(x, y)` or `|x| { x + 5 }(3)`.
     Function {
@@ -77,7 +77,7 @@ pub enum Expr<'a, T: Grammar<'a>> {
     Object(ObjectExpr<'a, T>),
 }
 
-impl<'a, T: Grammar<'a>> Expr<'a, T> {
+impl<'a, T: Grammar> Expr<'a, T> {
     /// Returns LHS of the binary expression. If this is not a binary expression, returns `None`.
     pub fn binary_lhs(&self) -> Option<&SpannedExpr<'a, T>> {
         match self {
@@ -113,7 +113,7 @@ impl<'a, T: Grammar<'a>> Expr<'a, T> {
     }
 }
 
-impl<'a, T: Grammar<'a>> Clone for Expr<'a, T> {
+impl<'a, T: Grammar> Clone for Expr<'a, T> {
     fn clone(&self) -> Self {
         match self {
             Self::Variable => Self::Variable,
@@ -160,9 +160,9 @@ impl<'a, T: Grammar<'a>> Clone for Expr<'a, T> {
 
 impl<'a, T> PartialEq for Expr<'a, T>
 where
-    T: Grammar<'a>,
+    T: Grammar,
     T::Lit: PartialEq,
-    T::Type: PartialEq,
+    T::Type<'a>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -21,13 +21,13 @@ use crate::{
 /// Object expression, such as `#{ x, y: x + 2 }`.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct ObjectExpr<'a, T: Grammar<'a>> {
+pub struct ObjectExpr<'a, T: Grammar> {
     /// Fields. Each field is the field name and an optional expression (that is, parts
     /// before and after the colon char `:`, respectively).
     pub fields: Vec<(Spanned<'a>, Option<SpannedExpr<'a, T>>)>,
 }
 
-impl<'a, T: Grammar<'a>> Clone for ObjectExpr<'a, T> {
+impl<'a, T: Grammar> Clone for ObjectExpr<'a, T> {
     fn clone(&self) -> Self {
         Self {
             fields: self.fields.clone(),
@@ -35,7 +35,7 @@ impl<'a, T: Grammar<'a>> Clone for ObjectExpr<'a, T> {
     }
 }
 
-impl<'a, T: Grammar<'a>> PartialEq for ObjectExpr<'a, T> {
+impl<'a, T: Grammar> PartialEq for ObjectExpr<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         self.fields == other.fields
     }
@@ -44,19 +44,19 @@ impl<'a, T: Grammar<'a>> PartialEq for ObjectExpr<'a, T> {
 /// Statement: an expression or a variable assignment.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum Statement<'a, T: Grammar<'a>> {
+pub enum Statement<'a, T: Grammar> {
     /// Expression, e.g., `x + (1, 2)`.
     Expr(SpannedExpr<'a, T>),
     /// Assigment, e.g., `(x, y) = (5, 8)`.
     Assignment {
         /// LHS of the assignment.
-        lhs: SpannedLvalue<'a, T::Type>,
+        lhs: SpannedLvalue<'a, T::Type<'a>>,
         /// RHS of the assignment.
         rhs: Box<SpannedExpr<'a, T>>,
     },
 }
 
-impl<'a, T: Grammar<'a>> Statement<'a, T> {
+impl<'a, T: Grammar> Statement<'a, T> {
     /// Returns the type of this statement.
     pub fn ty(&self) -> StatementType {
         match self {
@@ -66,7 +66,7 @@ impl<'a, T: Grammar<'a>> Statement<'a, T> {
     }
 }
 
-impl<'a, T: Grammar<'a>> Clone for Statement<'a, T> {
+impl<'a, T: Grammar> Clone for Statement<'a, T> {
     fn clone(&self) -> Self {
         match self {
             Self::Expr(expr) => Self::Expr(expr.clone()),
@@ -80,9 +80,9 @@ impl<'a, T: Grammar<'a>> Clone for Statement<'a, T> {
 
 impl<'a, T> PartialEq for Statement<'a, T>
 where
-    T: Grammar<'a>,
+    T: Grammar,
     T::Lit: PartialEq,
-    T::Type: PartialEq,
+    T::Type<'a>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -128,14 +128,14 @@ impl fmt::Display for StatementType {
 /// A block may end with a return expression, e.g., `{ x = 1; x }`.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct Block<'a, T: Grammar<'a>> {
+pub struct Block<'a, T: Grammar> {
     /// Statements in the block.
     pub statements: Vec<SpannedStatement<'a, T>>,
     /// The last statement in the block which is returned from the block.
     pub return_value: Option<Box<SpannedExpr<'a, T>>>,
 }
 
-impl<'a, T: Grammar<'a>> Clone for Block<'a, T> {
+impl<'a, T: Grammar> Clone for Block<'a, T> {
     fn clone(&self) -> Self {
         Self {
             statements: self.statements.clone(),
@@ -146,16 +146,16 @@ impl<'a, T: Grammar<'a>> Clone for Block<'a, T> {
 
 impl<'a, T> PartialEq for Block<'a, T>
 where
-    T: Grammar<'a>,
+    T: Grammar,
     T::Lit: PartialEq,
-    T::Type: PartialEq,
+    T::Type<'a>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.return_value == other.return_value && self.statements == other.statements
     }
 }
 
-impl<'a, T: Grammar<'a>> Block<'a, T> {
+impl<'a, T: Grammar> Block<'a, T> {
     /// Creates an empty block.
     pub fn empty() -> Self {
         Self {
@@ -170,14 +170,14 @@ impl<'a, T: Grammar<'a>> Block<'a, T> {
 /// A function definition consists of a list of arguments and the function body.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct FnDefinition<'a, T: Grammar<'a>> {
+pub struct FnDefinition<'a, T: Grammar> {
     /// Function arguments, e.g., `x, y`.
-    pub args: Spanned<'a, Destructure<'a, T::Type>>,
+    pub args: Spanned<'a, Destructure<'a, T::Type<'a>>>,
     /// Function body, e.g., `x + y`.
     pub body: Block<'a, T>,
 }
 
-impl<'a, T: Grammar<'a>> Clone for FnDefinition<'a, T> {
+impl<'a, T: Grammar> Clone for FnDefinition<'a, T> {
     fn clone(&self) -> Self {
         Self {
             args: self.args.clone(),
@@ -188,9 +188,9 @@ impl<'a, T: Grammar<'a>> Clone for FnDefinition<'a, T> {
 
 impl<'a, T> PartialEq for FnDefinition<'a, T>
 where
-    T: Grammar<'a>,
+    T: Grammar,
     T::Lit: PartialEq,
-    T::Type: PartialEq,
+    T::Type<'a>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.args == other.args && self.body == other.body

--- a/parser/src/grammars/traits.rs
+++ b/parser/src/grammars/traits.rs
@@ -152,10 +152,10 @@ pub trait ParseLiteral: 'static {
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// struct Num;
 ///
-/// impl Grammar<'_> for IntegerGrammar {
-///     type Type = Num;
+/// impl Grammar for IntegerGrammar {
+///     type Type<'a> = Num;
 ///
-///     fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+///     fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
 ///         use nom::{bytes::complete::tag, combinator::map};
 ///         map(tag("Num"), |_| Num)(input)
 ///     }
@@ -239,7 +239,7 @@ impl<'a> IntoInputSpan<'a> for &'a str {
 /// #   }
 /// }
 ///
-/// impl Parse<'_> for IntegerGrammar {
+/// impl Parse for IntegerGrammar {
 ///     type Base = Untyped<Self>;
 ///     const FEATURES: Features = Features::empty();
 /// }

--- a/parser/src/grammars/traits.rs
+++ b/parser/src/grammars/traits.rs
@@ -6,7 +6,7 @@ use core::{fmt, marker::PhantomData};
 
 use crate::{
     parser::{statements, streaming_statements},
-    Block, Error, ErrorKind, InputSpan, NomResult, SpannedError,
+    Block, Error, ErrorKind, InputSpan, NomResult,
 };
 
 bitflags! {
@@ -259,7 +259,7 @@ pub trait Parse {
     const FEATURES: Features;
 
     /// Parses a list of statements.
-    fn parse_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
+    fn parse_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error>
     where
         I: IntoInputSpan<'a>,
         Self: Sized,
@@ -268,7 +268,7 @@ pub trait Parse {
     }
 
     /// Parses a potentially incomplete list of statements.
-    fn parse_streaming_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
+    fn parse_streaming_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error>
     where
         I: IntoInputSpan<'a>,
         Self: Sized,
@@ -304,7 +304,7 @@ impl<T: ParseLiteral> Grammar for Untyped<T> {
     #[inline]
     fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
         let err = anyhow!("Type annotations are not supported by this parser");
-        let err = SpannedError::new(input, ErrorKind::Type(err));
+        let err = Error::new(input, ErrorKind::Type(err));
         Err(NomErr::Failure(err))
     }
 }
@@ -385,7 +385,7 @@ impl<T: ParseLiteral, Ty: MockTypes> Grammar for WithMockedTypes<T, Ty> {
                 }
             }
             let err = anyhow!("Unrecognized type annotation");
-            let err = SpannedError::new(input, ErrorKind::Type(err));
+            let err = Error::new(input, ErrorKind::Type(err));
             Err(NomErr::Failure(err))
         }
 

--- a/parser/src/grammars/traits.rs
+++ b/parser/src/grammars/traits.rs
@@ -178,17 +178,16 @@ pub trait ParseLiteral: 'static {
 /// # Ok(())
 /// # }
 /// ```
-pub trait Grammar<'a>: ParseLiteral {
-    /// Type of the type annotation used in the grammar.
-    type Type: Clone + fmt::Debug;
+pub trait Grammar: ParseLiteral {
+    /// Type of the type annotation used in the grammar. This type may be parametric by the input lifetime.
+    type Type<'a>: 'a + Clone + fmt::Debug;
 
     /// Attempts to parse a type annotation.
     ///
     /// # Return value
     ///
     /// The output should follow `nom` conventions on errors / failures.
-    fn parse_type(input: InputSpan<'a>) -> NomResult<'a, Self::Type>;
-    // FIXME: why is `'a` not here?
+    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>>;
 }
 
 /// Helper trait allowing `Parse` to accept multiple types as inputs.
@@ -253,14 +252,14 @@ impl<'a> IntoInputSpan<'a> for &'a str {
 /// # Ok(())
 /// # }
 /// ```
-pub trait Parse<'a> {
+pub trait Parse {
     /// Base for the grammar providing the literal and type annotation parsers.
-    type Base: Grammar<'a>;
+    type Base: Grammar;
     /// Features supported by this grammar.
     const FEATURES: Features;
 
     /// Parses a list of statements.
-    fn parse_statements<I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
+    fn parse_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
     where
         I: IntoInputSpan<'a>,
         Self: Sized,
@@ -269,7 +268,7 @@ pub trait Parse<'a> {
     }
 
     /// Parses a potentially incomplete list of statements.
-    fn parse_streaming_statements<I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
+    fn parse_streaming_statements<'a, I>(input: I) -> Result<Block<'a, Self::Base>, Error<'a>>
     where
         I: IntoInputSpan<'a>,
         Self: Sized,
@@ -299,18 +298,18 @@ impl<T: ParseLiteral> ParseLiteral for Untyped<T> {
     }
 }
 
-impl<T: ParseLiteral> Grammar<'_> for Untyped<T> {
-    type Type = ();
+impl<T: ParseLiteral> Grammar for Untyped<T> {
+    type Type<'a> = ();
 
     #[inline]
-    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
         let err = anyhow!("Type annotations are not supported by this parser");
         let err = SpannedError::new(input, ErrorKind::Type(err));
         Err(NomErr::Failure(err))
     }
 }
 
-impl<T: ParseLiteral> Parse<'_> for Untyped<T> {
+impl<T: ParseLiteral> Parse for Untyped<T> {
     type Base = Self;
 
     const FEATURES: Features = Features::all().without(Features::TYPE_ANNOTATIONS);
@@ -326,7 +325,7 @@ impl<T: ParseLiteral> Parse<'_> for Untyped<T> {
 // TODO: consider name change (`Parser`?)
 pub struct Typed<T>(PhantomData<T>);
 
-impl<'a, T: Grammar<'a>> Parse<'a> for Typed<T> {
+impl<T: Grammar> Parse for Typed<T> {
     type Base = T;
 
     const FEATURES: Features = Features::all();
@@ -372,10 +371,10 @@ impl<T: ParseLiteral, Ty: MockTypes> ParseLiteral for WithMockedTypes<T, Ty> {
     }
 }
 
-impl<T: ParseLiteral, Ty: MockTypes> Grammar<'_> for WithMockedTypes<T, Ty> {
-    type Type = ();
+impl<T: ParseLiteral, Ty: MockTypes> Grammar for WithMockedTypes<T, Ty> {
+    type Type<'a> = ();
 
-    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
         use nom::Slice;
 
         fn type_parser<M: MockTypes>(input: InputSpan<'_>) -> NomResult<'_, ()> {
@@ -394,7 +393,7 @@ impl<T: ParseLiteral, Ty: MockTypes> Grammar<'_> for WithMockedTypes<T, Ty> {
     }
 }
 
-impl<T: ParseLiteral, Ty: MockTypes> Parse<'_> for WithMockedTypes<T, Ty> {
+impl<T: ParseLiteral, Ty: MockTypes> Parse for WithMockedTypes<T, Ty> {
     type Base = Self;
 
     const FEATURES: Features = Features::all();

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -157,7 +157,7 @@ pub use crate::{
         LvalueType, ObjectDestructure, ObjectDestructureField, ObjectExpr, SpannedExpr,
         SpannedLvalue, SpannedStatement, Statement, StatementType,
     },
-    error::{Context, Error, ErrorKind, SpannedError, UnsupportedType},
+    error::{Context, Error, ErrorKind, UnsupportedType},
     ops::{BinaryOp, Op, OpPriority, UnaryOp},
     parser::is_valid_variable_name,
     spans::{with_span, InputSpan, LocatedSpan, Location, NomResult, Spanned},

--- a/parser/src/parser/expr.rs
+++ b/parser/src/parser/expr.rs
@@ -315,7 +315,7 @@ fn fold_args<'a, T: Grammar>(
     input: InputSpan<'a>,
     mut base: SpannedExpr<'a, T>,
     calls: Vec<Spanned<'a, MethodOrFnCall<'a, T>>>,
-) -> Result<SpannedExpr<'a, T>, NomErr<Error<'a>>> {
+) -> Result<SpannedExpr<'a, T>, NomErr<Error>> {
     // Do we need to reorder unary op application and method calls? This is only applicable if:
     //
     // - `base` is a literal (as a corollary, `-` / `!` may be a start of a literal)
@@ -474,7 +474,7 @@ fn fold_binary_expr<'a, T: Grammar>(
     input: InputSpan<'a>,
     first: SpannedExpr<'a, T>,
     rest: Vec<(Spanned<'a, BinaryOp>, SpannedExpr<'a, T>)>,
-) -> Result<SpannedExpr<'a, T>, Error<'a>> {
+) -> Result<SpannedExpr<'a, T>, Error> {
     let mut right_contour: Vec<BinaryOp> = vec![];
 
     rest.into_iter().try_fold(first, |mut acc, (new_op, expr)| {

--- a/parser/src/parser/expr.rs
+++ b/parser/src/parser/expr.rs
@@ -30,9 +30,9 @@ use crate::{
 /// # Return value
 ///
 /// The second component of the returned tuple is set to `true` if the list is `,`-terminated.
-fn fn_args<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, (Vec<SpannedExpr<'a, T::Base>>, bool)>
+fn fn_args<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, (Vec<SpannedExpr<'_, T::Base>>, bool)>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let maybe_comma = map(opt(preceded(ws::<Ty>, tag_char(','))), |c| c.is_some());
@@ -49,9 +49,9 @@ where
 
 /// Expression enclosed in parentheses. This may be a simple value (e.g., `(1 + 2)`)
 /// or a tuple (e.g., `(x, y)`), depending on the number of comma-separated terms.
-pub(super) fn paren_expr<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+pub(super) fn paren_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     with_span(fn_args::<T, Ty>)(input).and_then(|(rest, parsed)| {
@@ -77,9 +77,9 @@ where
 }
 
 /// Parses a block and wraps it into an `Expr`.
-fn block_expr<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+fn block_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     map(with_span(block::<T, Ty>), |spanned| {
@@ -87,11 +87,11 @@ where
     })(input)
 }
 
-fn object_expr_field<'a, T, Ty>(
-    input: InputSpan<'a>,
-) -> NomResult<'a, (Spanned<'a>, Option<SpannedExpr<'a, T::Base>>)>
+fn object_expr_field<T, Ty>(
+    input: InputSpan<'_>,
+) -> NomResult<'_, (Spanned<'_>, Option<SpannedExpr<'_, T::Base>>)>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let colon_sep = delimited(ws::<Ty>, tag_char(':'), ws::<Ty>);
@@ -101,11 +101,9 @@ where
     ))(input)
 }
 
-pub(super) fn object_expr<'a, T, Ty>(
-    input: InputSpan<'a>,
-) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+pub(super) fn object_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let object = preceded(
@@ -125,9 +123,9 @@ where
 }
 
 /// Parses a function definition and wraps it into an `Expr`.
-fn fn_def_expr<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+fn fn_def_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     map(with_span(fn_def::<T, Ty>), |spanned| {
@@ -139,14 +137,14 @@ where
 ///
 /// From the construction, the evaluation priorities within such an expression are always higher
 /// than for possible binary ops surrounding it.
-fn simplest_expr<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+fn simplest_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
-    fn error<'b, T>(input: InputSpan<'b>) -> NomResult<'b, SpannedExpr<'b, T::Base>>
+    fn error<T>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
     where
-        T: Parse<'b>,
+        T: Parse,
     {
         let e = ErrorKind::Leftovers.with_span(&input.into());
         Err(NomErr::Error(e))
@@ -195,23 +193,23 @@ where
 }
 
 #[derive(Debug)]
-struct MethodOrFnCall<'a, T: Grammar<'a>> {
+struct MethodOrFnCall<'a, T: Grammar> {
     separator: Option<Spanned<'a>>,
     fn_name: Option<SpannedExpr<'a, T>>,
     args: Option<Vec<SpannedExpr<'a, T>>>,
 }
 
-impl<'a, T: Grammar<'a>> MethodOrFnCall<'a, T> {
+impl<T: Grammar> MethodOrFnCall<'_, T> {
     fn is_method(&self) -> bool {
         self.fn_name.is_some() && self.args.is_some()
     }
 }
 
-type MethodParseResult<'a, T> = NomResult<'a, MethodOrFnCall<'a, <T as Parse<'a>>::Base>>;
+type MethodParseResult<'a, T> = NomResult<'a, MethodOrFnCall<'a, <T as Parse>::Base>>;
 
-fn fn_call<'a, T, Ty>(input: InputSpan<'a>) -> MethodParseResult<'a, T>
+fn fn_call<T, Ty>(input: InputSpan<'_>) -> MethodParseResult<'_, T>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     map(fn_args::<T, Ty>, |(args, _)| MethodOrFnCall {
@@ -221,9 +219,9 @@ where
     })(input)
 }
 
-fn method_or_fn_call<'a, T, Ty>(input: InputSpan<'a>) -> MethodParseResult<'a, T>
+fn method_or_fn_call<T, Ty>(input: InputSpan<'_>) -> MethodParseResult<'_, T>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let var_name_or_digits = alt((var_name, take_while1(|c: char| c.is_ascii_digit())));
@@ -268,9 +266,9 @@ where
 }
 
 /// Expression, which includes, besides `simplest_expr`s, function calls.
-fn expr_with_calls<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+fn expr_with_calls<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let method_or_fn_call = if T::FEATURES.contains(Features::METHODS) {
@@ -289,11 +287,9 @@ where
 }
 
 /// Simple expression, which includes `expr_with_calls` and type casts.
-pub(super) fn simple_expr<'a, T, Ty>(
-    input: InputSpan<'a>,
-) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+pub(super) fn simple_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let as_keyword = delimited(ws::<Ty>, tag("as"), mandatory_ws::<Ty>);
@@ -315,7 +311,7 @@ where
 
 #[allow(clippy::option_if_let_else, clippy::range_plus_one)]
 // ^-- See explanations in the function code.
-fn fold_args<'a, T: Grammar<'a>>(
+fn fold_args<'a, T: Grammar>(
     input: InputSpan<'a>,
     mut base: SpannedExpr<'a, T>,
     calls: Vec<Spanned<'a, MethodOrFnCall<'a, T>>>,
@@ -401,11 +397,9 @@ fn fold_args<'a, T: Grammar<'a>>(
 
 /// Parses an expression with binary operations into a tree with the hierarchy reflecting
 /// the evaluation order of the operations.
-pub(super) fn binary_expr<'a, T, Ty>(
-    input: InputSpan<'a>,
-) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+pub(super) fn binary_expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     // First, we parse the expression into a list with simple expressions interspersed
@@ -476,7 +470,7 @@ where
 // 1   *
 //    / \
 //   2  foo(x, y)
-fn fold_binary_expr<'a, T: Grammar<'a>>(
+fn fold_binary_expr<'a, T: Grammar>(
     input: InputSpan<'a>,
     first: SpannedExpr<'a, T>,
     rest: Vec<(Spanned<'a, BinaryOp>, SpannedExpr<'a, T>)>,
@@ -540,9 +534,9 @@ fn fold_binary_expr<'a, T: Grammar<'a>>(
     })
 }
 
-pub(super) fn expr<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedExpr<'a, T::Base>>
+pub(super) fn expr<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedExpr<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     context(Context::Expr.to_str(), binary_expr::<T, Ty>)(input)

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -30,9 +30,9 @@ use crate::{
 };
 
 #[allow(clippy::option_if_let_else)]
-fn statement<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, SpannedStatement<'a, T::Base>>
+fn statement<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedStatement<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let assignment = tuple((tag("="), peek(not(tag_char('=')))));
@@ -58,9 +58,9 @@ where
 }
 
 /// Parses a complete list of statements.
-pub(crate) fn statements<'a, T>(input_span: InputSpan<'a>) -> Result<Block<'a, T::Base>, Error<'a>>
+pub(crate) fn statements<T>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error<'_>>
 where
-    T: Parse<'a>,
+    T: Parse,
 {
     if !input_span.fragment().is_ascii() {
         return Err(Error::new(input_span, ErrorKind::NonAsciiInput));
@@ -69,11 +69,11 @@ where
 }
 
 /// Parses a potentially incomplete list of statements.
-pub(crate) fn streaming_statements<'a, T>(
-    input_span: InputSpan<'a>,
-) -> Result<Block<'a, T::Base>, Error<'a>>
+pub(crate) fn streaming_statements<T>(
+    input_span: InputSpan<'_>,
+) -> Result<Block<'_, T::Base>, Error<'_>>
 where
-    T: Parse<'a>,
+    T: Parse,
 {
     if !input_span.fragment().is_ascii() {
         return Err(Error::new(input_span, ErrorKind::NonAsciiInput));
@@ -83,9 +83,9 @@ where
         .or_else(|_| statements_inner::<T, Streaming>(input_span))
 }
 
-fn statements_inner<'a, T, Ty>(input_span: InputSpan<'a>) -> Result<Block<'a, T::Base>, Error<'a>>
+fn statements_inner<T, Ty>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error<'_>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     delimited(ws::<Ty>, separated_statements::<T, Ty>, ws::<Ty>)(input_span)
@@ -102,20 +102,18 @@ where
         })
 }
 
-fn separated_statement<'a, T, Ty>(
-    input: InputSpan<'a>,
-) -> NomResult<'a, SpannedStatement<'a, T::Base>>
+fn separated_statement<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, SpannedStatement<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     terminated(statement::<T, Ty>, preceded(ws::<Ty>, tag_char(';')))(input)
 }
 
 /// List of statements separated by semicolons.
-fn separated_statements<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, Block<'a, T::Base>>
+fn separated_statements<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, Block<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     map(
@@ -131,9 +129,9 @@ where
 }
 
 /// Block of statements, e.g., `{ x = 3; x + y }`.
-fn block<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, Block<'a, T::Base>>
+fn block<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, Block<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     preceded(
@@ -146,9 +144,9 @@ where
 }
 
 /// Function definition, e.g., `|x, y: Sc| { x + y }`.
-fn fn_def<'a, T, Ty>(input: InputSpan<'a>) -> NomResult<'a, FnDefinition<'a, T::Base>>
+fn fn_def<T, Ty>(input: InputSpan<'_>) -> NomResult<'_, FnDefinition<'_, T::Base>>
 where
-    T: Parse<'a>,
+    T: Parse,
     Ty: GrammarType,
 {
     let body_parser = alt((

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -58,7 +58,7 @@ where
 }
 
 /// Parses a complete list of statements.
-pub(crate) fn statements<T>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error<'_>>
+pub(crate) fn statements<T>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error>
 where
     T: Parse,
 {
@@ -71,7 +71,7 @@ where
 /// Parses a potentially incomplete list of statements.
 pub(crate) fn streaming_statements<T>(
     input_span: InputSpan<'_>,
-) -> Result<Block<'_, T::Base>, Error<'_>>
+) -> Result<Block<'_, T::Base>, Error>
 where
     T: Parse,
 {
@@ -83,7 +83,7 @@ where
         .or_else(|_| statements_inner::<T, Streaming>(input_span))
 }
 
-fn statements_inner<T, Ty>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error<'_>>
+fn statements_inner<T, Ty>(input_span: InputSpan<'_>) -> Result<Block<'_, T::Base>, Error>
 where
     T: Parse,
     Ty: GrammarType,

--- a/parser/src/parser/tests/features.rs
+++ b/parser/src/parser/tests/features.rs
@@ -43,7 +43,7 @@ fn type_hints_when_switched_off() {
 
     let input = InputSpan::new("(x, y: Sc) = (1 + 2, 3 + 5)");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if spanned.span().location_offset() == 5);
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().location_offset() == 5);
 
     let input = InputSpan::new("duplicate = |x| { x * (1, 2) }");
     let (rem, _) = statement::<SimpleGrammar, Complete>(input).unwrap();
@@ -51,7 +51,7 @@ fn type_hints_when_switched_off() {
 
     let input = InputSpan::new("duplicate = |x: Sc| { x * (1, 2) }");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if *spanned.span().fragment() == ":");
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().span(&input) == ":");
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn fn_defs_when_switched_off() {
 
     let input = InputSpan::new("foo = |x| { x + 3 }");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Error(spanned) if *spanned.span().fragment() == "|");
+    assert_matches!(err, NomErr::Error(spanned) if spanned.location().span(&input) == "|");
 }
 
 #[test]
@@ -83,11 +83,11 @@ fn tuples_when_switched_off() {
 
     let input = InputSpan::new("tup = (1 + 2, 3 + 5)");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if spanned.span().location_offset() == 6);
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().location_offset() == 6);
 
     let input = InputSpan::new("(x, y) = (1 + 2, 3 + 5)");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if spanned.span().location_offset() == 0);
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().location_offset() == 0);
 
     let input = InputSpan::new("{ x, y } = #{ x: 1, y: 2 }");
     let stmt = statement::<SimpleGrammar, Complete>(input).unwrap().1;
@@ -110,11 +110,11 @@ fn blocks_when_switched_off() {
 
     let input = InputSpan::new("x = { y = 10; y * 2 }");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Error(spanned) if spanned.span().location_offset() == 4);
+    assert_matches!(err, NomErr::Error(spanned) if spanned.location().location_offset() == 4);
 
     let input = InputSpan::new("foo({ y = 10; y * 2 }, z)");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if spanned.span().location_offset() == 4);
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().location_offset() == 4);
 }
 
 #[test]
@@ -163,8 +163,8 @@ where
     let NomErr::Failure(spanned_err) = err else {
         panic!("Unexpected error: {err}");
     };
-    assert_eq!(spanned_err.span().location_offset(), 2);
-    assert_eq!(*spanned_err.span().fragment(), op.as_str());
+    assert_eq!(spanned_err.location().location_offset(), 2);
+    assert_eq!(spanned_err.location().span(&input), op.as_str());
     assert_matches!(
         *spanned_err.kind(),
         ErrorKind::UnsupportedOp(Op::Binary(real_op)) if real_op == op
@@ -207,11 +207,11 @@ fn object_expressions_when_switched_off() {
 
     let input = InputSpan::new("#{ x = 1; y = 2; };");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Error(spanned) if *spanned.span().fragment() == "#");
+    assert_matches!(err, NomErr::Error(spanned) if spanned.location().span(&input) == "#");
 
     let input = InputSpan::new("{ x, y } = #{ x = 1; y = 2; }");
     let err = statement::<SimpleGrammar, Complete>(input).unwrap_err();
-    assert_matches!(err, NomErr::Failure(spanned) if spanned.span().location_offset() == 3);
+    assert_matches!(err, NomErr::Failure(spanned) if spanned.location().location_offset() == 3);
 
     let input = InputSpan::new("(x, y) = (1 + 2, 3 + 5)");
     let stmt = statement::<SimpleGrammar, Complete>(input).unwrap().1;

--- a/parser/src/parser/tests/features.rs
+++ b/parser/src/parser/tests/features.rs
@@ -59,7 +59,7 @@ fn fn_defs_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::FN_DEFINITIONS);
@@ -75,7 +75,7 @@ fn tuples_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::TUPLES);
@@ -102,7 +102,7 @@ fn blocks_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::BLOCKS);
@@ -122,7 +122,7 @@ fn methods_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::METHODS);
@@ -142,7 +142,7 @@ fn order_comparisons_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::ORDER_COMPARISONS);
@@ -155,7 +155,7 @@ fn order_comparisons_when_switched_off() {
 
 fn assert_binary_op_is_not_parsed<T>(op: BinaryOp)
 where
-    T: for<'a> Parse<'a>,
+    T: Parse,
 {
     let input = format!("x {} 1;", op.as_str());
     let input = InputSpan::new(&input);
@@ -176,7 +176,7 @@ fn boolean_ops_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::BOOLEAN_OPS);
@@ -199,7 +199,7 @@ fn object_expressions_when_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::OBJECTS);
@@ -226,7 +226,7 @@ fn object_expressions_when_blocks_are_switched_off() {
     #[derive(Debug, Clone)]
     struct SimpleGrammar;
 
-    impl Parse<'_> for SimpleGrammar {
+    impl Parse for SimpleGrammar {
         type Base = FieldGrammarBase;
 
         const FEATURES: Features = Features::all().without(Features::BLOCKS);

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -155,10 +155,10 @@ impl ParseLiteral for FieldGrammarBase {
     }
 }
 
-impl Grammar<'_> for FieldGrammarBase {
-    type Type = ValueType;
+impl Grammar for FieldGrammarBase {
+    type Type<'a> = ValueType;
 
-    fn parse_type(span: InputSpan<'_>) -> NomResult<'_, Self::Type> {
+    fn parse_type(span: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
         type_info::<Streaming>(span)
     }
 }

--- a/parser/src/parser/tests/object.rs
+++ b/parser/src/parser/tests/object.rs
@@ -183,7 +183,7 @@ fn object_errors() {
     let NomErr::Failure(err) = err else {
         panic!("Unexpected error: {err:?}");
     };
-    assert_eq!(err.span(), sp(5, "=", ()));
+    assert_eq!(err.location(), sp(5, "=", ()).into());
 }
 
 #[test]

--- a/parser/src/parser/tests/order.rs
+++ b/parser/src/parser/tests/order.rs
@@ -146,7 +146,7 @@ fn chained_comparisons() {
             panic!("Unexpected error: {err:?}");
         };
         assert_matches!(err.kind(), ErrorKind::ChainedComparison);
-        assert_eq!(*err.span().fragment(), input);
+        assert_eq!(err.location().span(input), input);
     }
 }
 
@@ -158,7 +158,7 @@ fn chained_comparisons_with_larger_context() {
         panic!("Unexpected error: {err:?}");
     };
     assert_matches!(err.kind(), ErrorKind::ChainedComparison);
-    assert_eq!(*err.span().fragment(), "1 + 2 > x.abs() == 3");
+    assert_eq!(err.location().span(input), "1 + 2 > x.abs() == 3");
 }
 
 #[test]

--- a/parser/src/spans.rs
+++ b/parser/src/spans.rs
@@ -10,7 +10,7 @@ use crate::{
 /// Code span.
 pub type InputSpan<'a> = nom_locate::LocatedSpan<&'a str, ()>;
 /// Parsing outcome generalized by the type returned on success.
-pub type NomResult<'a, T> = nom::IResult<InputSpan<'a>, T, Error<'a>>;
+pub type NomResult<'a, T> = nom::IResult<InputSpan<'a>, T, Error>;
 
 /// Code span together with information related to where it is located in the code.
 ///

--- a/typing/src/ast/conversion.rs
+++ b/typing/src/ast/conversion.rs
@@ -19,7 +19,9 @@ use crate::{
     DynConstraints, Function, Object, PrimitiveType, Slice, Tuple, Type, TypeEnvironment,
     UnknownLen,
 };
-use arithmetic_parser::{ErrorKind as ParseErrorKind, InputSpan, NomResult, Spanned, SpannedError};
+use arithmetic_parser::{
+    Error as ParseError, ErrorKind as ParseErrorKind, InputSpan, NomResult, Spanned,
+};
 
 /// Kinds of errors that can occur when converting `*Ast` types into their "main" counterparts.
 ///
@@ -483,7 +485,7 @@ fn parse_inner<'a, Ast>(
 fn from_str<'a, Ast>(
     parser: fn(InputSpan<'a>) -> NomResult<'a, Ast>,
     def: &'a str,
-) -> Result<Ast, SpannedError<&'a str>> {
+) -> Result<Ast, ParseError> {
     let input = InputSpan::new(def);
     let (_, ast) = parse_inner(parser, input).map_err(|err| match err {
         NomErr::Incomplete(_) => ParseErrorKind::Incomplete.with_span(&input.into()),
@@ -494,7 +496,7 @@ fn from_str<'a, Ast>(
 
 impl<'a> TypeAst<'a> {
     /// Parses type AST from a string.
-    pub fn try_from(def: &'a str) -> Result<SpannedTypeAst<'a>, SpannedError<&'a str>> {
+    pub fn try_from(def: &'a str) -> Result<SpannedTypeAst<'a>, ParseError> {
         from_str(TypeAst::parse, def)
     }
 }
@@ -516,7 +518,7 @@ impl<'a, Prim: PrimitiveType> TryFrom<&SpannedTypeAst<'a>> for Type<Prim> {
 }
 
 impl<'a> TryFrom<&'a str> for FunctionAst<'a> {
-    type Error = SpannedError<&'a str>;
+    type Error = ParseError;
 
     fn try_from(def: &'a str) -> Result<Self, Self::Error> {
         from_str(FunctionAst::parse, def)

--- a/typing/src/env/mod.rs
+++ b/typing/src/env/mod.rs
@@ -132,7 +132,7 @@ impl<Prim: PrimitiveType> TypeEnvironment<Prim> {
         block: &Block<'a, T>,
     ) -> Result<Type<Prim>, Errors<'a, Prim>>
     where
-        T: Grammar<'a, Type = TypeAst<'a>>,
+        T: Grammar<Type<'a> = TypeAst<'a>>,
         NumArithmetic: MapPrimitiveType<T::Lit, Prim = Prim> + TypeArithmetic<Prim>,
     {
         self.process_with_arithmetic(&NumArithmetic::without_comparisons(), block)
@@ -152,7 +152,7 @@ impl<Prim: PrimitiveType> TypeEnvironment<Prim> {
         block: &Block<'a, T>,
     ) -> Result<Type<Prim>, Errors<'a, Prim>>
     where
-        T: Grammar<'a, Type = TypeAst<'a>>,
+        T: Grammar<Type<'a> = TypeAst<'a>>,
         A: MapPrimitiveType<T::Lit, Prim = Prim> + TypeArithmetic<Prim>,
     {
         TypeProcessor::new(self, arithmetic).process_statements(block)

--- a/typing/src/env/processor.rs
+++ b/typing/src/env/processor.rs
@@ -89,7 +89,7 @@ where
 
     fn process_expr_inner<T>(&mut self, expr: &SpannedExpr<'a, T>) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         match &expr.extra {
             Expr::Variable => self.process_var(expr),
@@ -185,7 +185,7 @@ where
 
     fn process_block<T>(&mut self, block: &Block<'a, T>) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let top_level = self.scopes.len() == 1;
         for (i, statement) in block.statements.iter().enumerate() {
@@ -341,7 +341,7 @@ where
         field_name: &Spanned<'a>,
     ) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let field_str = *field_name.fragment();
         if let Ok(index) = field_str.parse::<usize>() {
@@ -361,7 +361,7 @@ where
         index: usize,
     ) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let receiver = self.env.substitutions.fast_resolve(receiver);
         match receiver {
@@ -407,7 +407,7 @@ where
 
     fn process_object<T>(&mut self, object: &ObjectExpr<'a, T>) -> Object<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         // Check that all field names are unique.
         let mut object_fields = HashMap::new();
@@ -436,7 +436,7 @@ where
         field_name: &str,
     ) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let mut errors = OpErrors::new();
         let return_type = self.new_type();
@@ -462,7 +462,7 @@ where
     ) -> Type<Prim>
     where
         'a: 'it,
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let arg_types: Vec<_> = args.map(|arg| self.process_expr_inner(arg)).collect();
         let return_type = self.new_type();
@@ -488,7 +488,7 @@ where
         inner: &SpannedExpr<'a, T>,
     ) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let inner_ty = self.process_expr_inner(inner);
         let context = UnaryOpContext { op, arg: inner_ty };
@@ -513,7 +513,7 @@ where
         rhs: &SpannedExpr<'a, T>,
     ) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let lhs_ty = self.process_expr_inner(lhs);
         let rhs_ty = self.process_expr_inner(rhs);
@@ -536,7 +536,7 @@ where
 
     fn process_fn_def<T>(&mut self, def: &FnDefinition<'a, T>) -> Function<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         self.scopes.push(HashMap::new());
         let was_in_function = mem::replace(&mut self.is_in_function, true);
@@ -567,7 +567,7 @@ where
 
     fn process_statement<T>(&mut self, statement: &SpannedStatement<'a, T>) -> Type<Prim>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         match &statement.extra {
             Statement::Expr(expr) => self.process_expr_inner(expr),
@@ -606,7 +606,7 @@ where
         block: &Block<'a, T>,
     ) -> Result<Type<Prim>, Errors<'a, Prim>>
     where
-        T: Grammar<'a, Lit = Val, Type = TypeAst<'a>>,
+        T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {
         let mut return_value = self.process_block(block);
 

--- a/typing/src/error/location.rs
+++ b/typing/src/error/location.rs
@@ -76,7 +76,7 @@ impl From<&str> for ErrorLocation {
 
 impl ErrorLocation {
     /// Walks the provided `expr` and returns the most exact span found in it.
-    pub(super) fn walk_expr<'a, T: Grammar<'a>>(
+    pub(super) fn walk_expr<'a, T: Grammar>(
         location: &[Self],
         expr: &SpannedExpr<'a, T>,
     ) -> Spanned<'a> {
@@ -100,7 +100,7 @@ impl ErrorLocation {
         refined
     }
 
-    fn step_into_expr<'r, 'a, T: Grammar<'a>>(
+    fn step_into_expr<'r, 'a, T: Grammar>(
         &self,
         mut expr: &'r SpannedExpr<'a, T>,
     ) -> Option<&'r SpannedExpr<'a, T>> {

--- a/typing/src/error/op_errors.rs
+++ b/typing/src/error/op_errors.rs
@@ -82,7 +82,7 @@ impl<Prim: PrimitiveType> OpErrors<'static, Prim> {
         }
     }
 
-    pub(crate) fn contextualize<'a, T: Grammar<'a>>(
+    pub(crate) fn contextualize<'a, T: Grammar>(
         self,
         span: &SpannedExpr<'a, T>,
         context: impl Into<ErrorContext<Prim>>,
@@ -161,7 +161,7 @@ struct ErrorPrecursor<Prim: PrimitiveType> {
 }
 
 impl<Prim: PrimitiveType> ErrorPrecursor<Prim> {
-    fn into_expr_error<'a, T: Grammar<'a>>(
+    fn into_expr_error<'a, T: Grammar>(
         self,
         context: ErrorContext<Prim>,
         root_expr: &SpannedExpr<'a, T>,

--- a/typing/src/lib.rs
+++ b/typing/src/lib.rs
@@ -270,17 +270,17 @@ impl<T: ParseLiteral> ParseLiteral for Annotated<T> {
     }
 }
 
-impl<'a, T: ParseLiteral> Grammar<'a> for Annotated<T> {
-    type Type = TypeAst<'a>;
+impl<T: ParseLiteral> Grammar for Annotated<T> {
+    type Type<'a> = TypeAst<'a>;
 
-    fn parse_type(input: InputSpan<'a>) -> NomResult<'a, Self::Type> {
+    fn parse_type(input: InputSpan<'_>) -> NomResult<'_, Self::Type<'_>> {
         use nom::combinator::map;
         map(TypeAst::parse, |ast| ast.extra)(input)
     }
 }
 
 /// Supports all syntax features.
-impl<T: ParseLiteral> Parse<'_> for Annotated<T> {
+impl<T: ParseLiteral> Parse for Annotated<T> {
     type Base = Self;
 
     const FEATURES: Features = Features::all();

--- a/typing/tests/integration/examples/mod.rs
+++ b/typing/tests/integration/examples/mod.rs
@@ -23,7 +23,7 @@ const EL_GAMAL_CODE: &str = include_str!("elgamal.script");
 #[derive(Debug, Clone, Copy)]
 struct U64Grammar;
 
-impl Parse<'_> for U64Grammar {
+impl Parse for U64Grammar {
     type Base = Annotated<NumGrammar<u64>>;
     // ^ We don't use large literals in code, so `u64` is fine
 


### PR DESCRIPTION
## What?

Removes lifetimes from certain types in the parser crate:

- `Error` type
- `Grammar` and `Parse` traits (make them use a generic associated `Type` instead of trait lifetimes).

## Why?

- Allows boxing `Error`, converting it to `anyhow::Error` etc.
- Makes `Grammar` and `Parse` traits more idiomatic.