### PR TITLE
Remove redundant lifetimes in typing crate

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -275,9 +275,11 @@ impl Reporter {
         self.report_error(&diagnostic)
     }
 
-    fn report_typing_errors(&self, errors: &TypingErrors<'_, Num>) -> io::Result<()> {
+    fn report_typing_errors(&self, errors: &TypingErrors<Num>) -> io::Result<()> {
         for err in errors.iter() {
-            let (file, range) = self.code_map.locate_in_most_recent_file(&err.main_span());
+            let (file, range) = self
+                .code_map
+                .locate_in_most_recent_file(&err.main_location());
 
             let label = Label::primary(file, range).with_message("Error occurred here");
             let diagnostic = Diagnostic::error()
@@ -562,10 +564,10 @@ impl<T: ReplLiteral> Env<T> {
         Ok(())
     }
 
-    fn process_types<'a>(
+    fn process_types(
         &mut self,
-        block: &Block<'a, Annotated<NumGrammar<T>>>,
-    ) -> io::Result<Result<(), TypingErrors<'a, Num>>> {
+        block: &Block<'_, Annotated<NumGrammar<T>>>,
+    ) -> io::Result<Result<(), TypingErrors<Num>>> {
         let res = self.type_env.as_mut().map_or(Ok(Type::Any), |type_env| {
             type_env.process_with_arithmetic(&NumArithmetic::with_comparisons(), block)
         });

--- a/typing/CHANGELOG.md
+++ b/typing/CHANGELOG.md
@@ -15,6 +15,13 @@ documented in this file. The project adheres to [Semantic Versioning](http://sem
 
 - Remove `Object::just()` constructor in favor of more general `From<[_; N]>` implementation. (#117)
 
+- Rename `ErrorLocation` to `ErrorPathFragment` and its getter in `Error` from `location()` to `path()`
+  in order to distinguish it from `Location` from the parser crate. (#124)
+
+### Removed
+
+- Remove lifetime generic from `Error` and related types. (#124)
+
 ### Fixed
 
 - Fix false positive during recursive type check for native parameterized functions.

--- a/typing/examples/strings.rs
+++ b/typing/examples/strings.rs
@@ -10,7 +10,7 @@ use arithmetic_parser::{
 use arithmetic_typing::{
     arith::*,
     defs::Assertions,
-    error::{ErrorLocation, OpErrors},
+    error::{ErrorPathFragment, OpErrors},
     Annotated, PrimitiveType, Type, TypeEnvironment,
 };
 
@@ -131,12 +131,12 @@ impl TypeArithmetic<StrType> for StrArithmetic {
                 substitutions.unify(
                     &Type::Prim(StrType::Str),
                     lhs_ty,
-                    errors.with_location(ErrorLocation::Lhs),
+                    errors.join_path(ErrorPathFragment::Lhs),
                 );
                 substitutions.unify(
                     &Type::Prim(StrType::Str),
                     rhs_ty,
-                    errors.with_location(ErrorLocation::Rhs),
+                    errors.join_path(ErrorPathFragment::Rhs),
                 );
                 Type::BOOL
             }

--- a/typing/src/arith/constraints.rs
+++ b/typing/src/arith/constraints.rs
@@ -239,17 +239,17 @@ where
         }
 
         for (i, element) in tuple.element_types() {
-            self.errors.push_location(i);
+            self.errors.push_path_fragment(i);
             self.visit_type(element);
-            self.errors.pop_location();
+            self.errors.pop_path_fragment();
         }
     }
 
     fn visit_object(&mut self, obj: &Object<Prim>) {
         for (name, element) in obj.iter() {
-            self.errors.push_location(name);
+            self.errors.push_path_fragment(name);
             self.visit_type(element);
-            self.errors.pop_location();
+            self.errors.pop_path_fragment();
         }
     }
 

--- a/typing/src/arith/mod.rs
+++ b/typing/src/arith/mod.rs
@@ -6,7 +6,7 @@ use num_traits::NumOps;
 use std::{fmt, str::FromStr};
 
 use crate::{
-    error::{ErrorKind, ErrorLocation, OpErrors},
+    error::{ErrorKind, ErrorPathFragment, OpErrors},
     PrimitiveType, Type,
 };
 use arithmetic_parser::{BinaryOp, UnaryOp};
@@ -135,12 +135,12 @@ impl<Prim: WithBoolean> TypeArithmetic<Prim> for BoolArithmetic {
                 substitutions.unify(
                     &Type::BOOL,
                     &context.lhs,
-                    errors.with_location(ErrorLocation::Lhs),
+                    errors.join_path(ErrorPathFragment::Lhs),
                 );
                 substitutions.unify(
                     &Type::BOOL,
                     &context.rhs,
-                    errors.with_location(ErrorLocation::Rhs),
+                    errors.join_path(ErrorPathFragment::Rhs),
                 );
                 Type::BOOL
             }
@@ -280,11 +280,11 @@ impl NumArithmetic {
                 let resolved_rhs_ty = resolved_rhs_ty.clone();
                 settings
                     .lin
-                    .visitor(substitutions, errors.with_location(ErrorLocation::Lhs))
+                    .visitor(substitutions, errors.join_path(ErrorPathFragment::Lhs))
                     .visit_type(lhs_ty);
                 settings
                     .lin
-                    .visitor(substitutions, errors.with_location(ErrorLocation::Rhs))
+                    .visitor(substitutions, errors.join_path(ErrorPathFragment::Rhs))
                     .visit_type(rhs_ty);
                 resolved_rhs_ty
             }
@@ -292,22 +292,22 @@ impl NumArithmetic {
                 let resolved_lhs_ty = resolved_lhs_ty.clone();
                 settings
                     .lin
-                    .visitor(substitutions, errors.with_location(ErrorLocation::Lhs))
+                    .visitor(substitutions, errors.join_path(ErrorPathFragment::Lhs))
                     .visit_type(lhs_ty);
                 settings
                     .lin
-                    .visitor(substitutions, errors.with_location(ErrorLocation::Rhs))
+                    .visitor(substitutions, errors.join_path(ErrorPathFragment::Rhs))
                     .visit_type(rhs_ty);
                 resolved_lhs_ty
             }
             _ => {
-                let lhs_is_valid = errors.with_location(ErrorLocation::Lhs).check(|errors| {
+                let lhs_is_valid = errors.join_path(ErrorPathFragment::Lhs).check(|errors| {
                     settings
                         .ops
                         .visitor(substitutions, errors)
                         .visit_type(lhs_ty);
                 });
-                let rhs_is_valid = errors.with_location(ErrorLocation::Rhs).check(|errors| {
+                let rhs_is_valid = errors.join_path(ErrorPathFragment::Rhs).check(|errors| {
                     settings
                         .ops
                         .visitor(substitutions, errors)
@@ -383,12 +383,12 @@ impl NumArithmetic {
                     substitutions.unify(
                         &ty,
                         &context.lhs,
-                        errors.with_location(ErrorLocation::Lhs),
+                        errors.join_path(ErrorPathFragment::Lhs),
                     );
                     substitutions.unify(
                         &ty,
                         &context.rhs,
-                        errors.with_location(ErrorLocation::Rhs),
+                        errors.join_path(ErrorPathFragment::Rhs),
                     );
                 } else {
                     let err = ErrorKind::unsupported(context.op);

--- a/typing/src/ast/conversion.rs
+++ b/typing/src/ast/conversion.rs
@@ -45,7 +45,7 @@ use arithmetic_parser::{
 ///
 /// let errors = TypeEnvironment::new().process_statements(&code).unwrap_err();
 /// let err = errors.into_iter().next().unwrap();
-/// assert_eq!(*err.main_span().fragment(), "'T");
+/// assert_eq!(*err.main_location().fragment(), "'T");
 /// assert_matches!(
 ///     err.kind(),
 ///     ErrorKind::AstConversion(AstConversionError::FreeTypeVar(id))
@@ -145,14 +145,14 @@ impl std::error::Error for AstConversionError {}
 pub(crate) struct AstConversionState<'r, 'a, Prim: PrimitiveType> {
     env: Option<&'r mut TypeEnvironment<Prim>>,
     known_constraints: ConstraintSet<Prim>,
-    errors: &'r mut Errors<'a, Prim>,
+    errors: &'r mut Errors<Prim>,
     len_params: HashMap<&'a str, usize>,
     type_params: HashMap<&'a str, usize>,
     is_in_function: bool,
 }
 
 impl<'r, 'a, Prim: PrimitiveType> AstConversionState<'r, 'a, Prim> {
-    pub fn new(env: &'r mut TypeEnvironment<Prim>, errors: &'r mut Errors<'a, Prim>) -> Self {
+    pub fn new(env: &'r mut TypeEnvironment<Prim>, errors: &'r mut Errors<Prim>) -> Self {
         let known_constraints = env.known_constraints.clone();
         Self {
             env: Some(env),
@@ -164,7 +164,7 @@ impl<'r, 'a, Prim: PrimitiveType> AstConversionState<'r, 'a, Prim> {
         }
     }
 
-    fn without_env(errors: &'r mut Errors<'a, Prim>) -> Self {
+    fn without_env(errors: &'r mut Errors<Prim>) -> Self {
         Self {
             env: None,
             known_constraints: Prim::well_known_constraints(),
@@ -451,7 +451,7 @@ impl<'a> FunctionAst<'a> {
     }
 
     /// Tries to convert this type into a [`Function`].
-    pub fn try_convert<Prim>(&self) -> Result<Function<Prim>, Errors<'a, Prim>>
+    pub fn try_convert<Prim>(&self) -> Result<Function<Prim>, Errors<Prim>>
     where
         Prim: PrimitiveType,
     {
@@ -502,7 +502,7 @@ impl<'a> TypeAst<'a> {
 }
 
 impl<'a, Prim: PrimitiveType> TryFrom<&SpannedTypeAst<'a>> for Type<Prim> {
-    type Error = Errors<'a, Prim>;
+    type Error = Errors<Prim>;
 
     fn try_from(ast: &SpannedTypeAst<'a>) -> Result<Self, Self::Error> {
         let mut errors = Errors::new();

--- a/typing/src/ast/conversion.rs
+++ b/typing/src/ast/conversion.rs
@@ -41,11 +41,11 @@ use arithmetic_parser::{
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let code = "bogus_slice: ['T; _] = (1, 2, 3);";
-/// let code = Annotated::<F32Grammar>::parse_statements(code)?;
+/// let ast = Annotated::<F32Grammar>::parse_statements(code)?;
 ///
-/// let errors = TypeEnvironment::new().process_statements(&code).unwrap_err();
+/// let errors = TypeEnvironment::new().process_statements(&ast).unwrap_err();
 /// let err = errors.into_iter().next().unwrap();
-/// assert_eq!(*err.main_location().fragment(), "'T");
+/// assert_eq!(err.main_location().span(code), "'T");
 /// assert_matches!(
 ///     err.kind(),
 ///     ErrorKind::AstConversion(AstConversionError::FreeTypeVar(id))

--- a/typing/src/defs.rs
+++ b/typing/src/defs.rs
@@ -56,7 +56,7 @@ use crate::{arith::WithBoolean, Function, Object, PrimitiveType, Type, UnknownLe
 /// let errors = env.process_statements(&ast).unwrap_err();
 /// assert_eq!(errors.len(), 1);
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_location().fragment(), "(_, _, _, z)");
+/// assert_eq!(err.main_location().span(code), "(_, _, _, z)");
 /// # assert_matches!(err.kind(), ErrorKind::TupleLenMismatch { .. });
 /// # Ok(())
 /// # }

--- a/typing/src/defs.rs
+++ b/typing/src/defs.rs
@@ -56,7 +56,7 @@ use crate::{arith::WithBoolean, Function, Object, PrimitiveType, Type, UnknownLe
 /// let errors = env.process_statements(&ast).unwrap_err();
 /// assert_eq!(errors.len(), 1);
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_span().fragment(), "(_, _, _, z)");
+/// assert_eq!(*err.main_location().fragment(), "(_, _, _, z)");
 /// # assert_matches!(err.kind(), ErrorKind::TupleLenMismatch { .. });
 /// # Ok(())
 /// # }

--- a/typing/src/env/mod.rs
+++ b/typing/src/env/mod.rs
@@ -130,7 +130,7 @@ impl<Prim: PrimitiveType> TypeEnvironment<Prim> {
     pub fn process_statements<'a, T>(
         &mut self,
         block: &Block<'a, T>,
-    ) -> Result<Type<Prim>, Errors<'a, Prim>>
+    ) -> Result<Type<Prim>, Errors<Prim>>
     where
         T: Grammar<Type<'a> = TypeAst<'a>>,
         NumArithmetic: MapPrimitiveType<T::Lit, Prim = Prim> + TypeArithmetic<Prim>,
@@ -150,7 +150,7 @@ impl<Prim: PrimitiveType> TypeEnvironment<Prim> {
         &mut self,
         arithmetic: &A,
         block: &Block<'a, T>,
-    ) -> Result<Type<Prim>, Errors<'a, Prim>>
+    ) -> Result<Type<Prim>, Errors<Prim>>
     where
         T: Grammar<Type<'a> = TypeAst<'a>>,
         A: MapPrimitiveType<T::Lit, Prim = Prim> + TypeArithmetic<Prim>,

--- a/typing/src/env/processor.rs
+++ b/typing/src/env/processor.rs
@@ -28,7 +28,7 @@ pub(super) struct TypeProcessor<'a, 'env, Val, Prim: PrimitiveType> {
     /// Variables assigned within the current lvalue (if it is being processed).
     /// Used to determine duplicate vars.
     lvalue_vars: Option<HashMap<&'a str, Spanned<'a>>>,
-    errors: Errors<'a, Prim>,
+    errors: Errors<Prim>,
 }
 
 impl<'env, Val, Prim: PrimitiveType> TypeProcessor<'_, 'env, Val, Prim> {
@@ -601,10 +601,7 @@ where
         }
     }
 
-    pub fn process_statements<T>(
-        mut self,
-        block: &Block<'a, T>,
-    ) -> Result<Type<Prim>, Errors<'a, Prim>>
+    pub fn process_statements<T>(mut self, block: &Block<'a, T>) -> Result<Type<Prim>, Errors<Prim>>
     where
         T: Grammar<Lit = Val, Type<'a> = TypeAst<'a>>,
     {

--- a/typing/src/env/processor.rs
+++ b/typing/src/env/processor.rs
@@ -260,7 +260,7 @@ where
             .enumerate()
             .map(|(i, element)| {
                 let loc = context.element(i);
-                self.process_lvalue(element, errors.with_location(loc))
+                self.process_lvalue(element, errors.join_path(loc))
             })
             .collect();
 
@@ -275,7 +275,7 @@ where
             .enumerate()
             .map(|(i, element)| {
                 let loc = context.end_element(i);
-                self.process_lvalue(element, errors.with_location(loc))
+                self.process_lvalue(element, errors.join_path(loc))
             })
             .collect();
 
@@ -315,7 +315,7 @@ where
 
             // We still process lvalues even if they correspond to duplicate fields.
             let field_type = if let Some(binding) = &field.binding {
-                self.process_lvalue(binding, errors.with_location(field_name))
+                self.process_lvalue(binding, errors.join_path(field_name))
             } else {
                 let new_type = self.new_type();
                 if object_fields[field_name] == field.field_name {

--- a/typing/src/error/kind.rs
+++ b/typing/src/error/kind.rs
@@ -3,8 +3,8 @@
 use std::{collections::HashSet, fmt};
 
 use crate::{
-    arith::Constraint, ast::AstConversionError, error::ErrorLocation, PrimitiveType, TupleIndex,
-    TupleLen, Type,
+    arith::Constraint, ast::AstConversionError, error::ErrorPathFragment, PrimitiveType,
+    TupleIndex, TupleLen, Type,
 };
 use arithmetic_parser::UnsupportedType;
 
@@ -19,19 +19,19 @@ pub enum TupleContext {
 }
 
 impl TupleContext {
-    pub(crate) fn element(self, index: usize) -> ErrorLocation {
+    pub(crate) fn element(self, index: usize) -> ErrorPathFragment {
         let index = TupleIndex::Start(index);
         match self {
-            Self::Generic => ErrorLocation::TupleElement(Some(index)),
-            Self::FnArgs => ErrorLocation::FnArg(Some(index)),
+            Self::Generic => ErrorPathFragment::TupleElement(Some(index)),
+            Self::FnArgs => ErrorPathFragment::FnArg(Some(index)),
         }
     }
 
-    pub(crate) fn end_element(self, index: usize) -> ErrorLocation {
+    pub(crate) fn end_element(self, index: usize) -> ErrorPathFragment {
         let index = TupleIndex::End(index);
         match self {
-            Self::Generic => ErrorLocation::TupleElement(Some(index)),
-            Self::FnArgs => ErrorLocation::FnArg(Some(index)),
+            Self::Generic => ErrorPathFragment::TupleElement(Some(index)),
+            Self::FnArgs => ErrorPathFragment::FnArg(Some(index)),
         }
     }
 }

--- a/typing/src/error/mod.rs
+++ b/typing/src/error/mod.rs
@@ -11,13 +11,13 @@ use crate::{
 use arithmetic_parser::{Location, Spanned, UnsupportedType};
 
 mod kind;
-mod path;
 mod op_errors;
+mod path;
 
 pub use self::{
     kind::{ErrorKind, TupleContext},
-    path::ErrorPathFragment,
     op_errors::OpErrors,
+    path::ErrorPathFragment,
 };
 
 /// Type error together with the corresponding code span.

--- a/typing/src/error/mod.rs
+++ b/typing/src/error/mod.rs
@@ -11,12 +11,12 @@ use crate::{
 use arithmetic_parser::{Location, Spanned, UnsupportedType};
 
 mod kind;
-mod location;
+mod path;
 mod op_errors;
 
 pub use self::{
     kind::{ErrorKind, TupleContext},
-    location::ErrorLocation,
+    path::ErrorPathFragment,
     op_errors::OpErrors,
 };
 
@@ -26,7 +26,7 @@ pub struct Error<Prim: PrimitiveType> {
     inner: Location<ErrorKind<Prim>>,
     root_location: Location,
     context: ErrorContext<Prim>,
-    location: Vec<ErrorLocation>,
+    path: Vec<ErrorPathFragment>,
 }
 
 impl<Prim: PrimitiveType> fmt::Display for Error<Prim> {
@@ -57,7 +57,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(kind).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -67,7 +67,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(ErrorKind::UndefinedVar(ident)).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -79,7 +79,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
                 .into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -89,7 +89,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(ErrorKind::RepeatedField(ident)).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -99,7 +99,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(kind).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -111,7 +111,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
                 .into(),
             root_location: span.into(),
             context: ErrorContext::None,
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -131,7 +131,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             context: ErrorContext::TupleIndex {
                 ty: Type::Tuple(receiver),
             },
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -140,7 +140,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(ErrorKind::CannotIndex).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::TupleIndex { ty: receiver },
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -149,7 +149,7 @@ impl<Prim: PrimitiveType> Error<Prim> {
             inner: span.copy_with_extra(ErrorKind::UnsupportedIndex).into(),
             root_location: span.with_no_extra().into(),
             context: ErrorContext::TupleIndex { ty: receiver },
-            location: vec![],
+            path: vec![],
         }
     }
 
@@ -173,11 +173,10 @@ impl<Prim: PrimitiveType> Error<Prim> {
         &self.context
     }
 
-    /// Gets the location of this error relative to the failed top-level operation.
+    /// Gets the path of this error relative to the failed top-level operation.
     /// This can be used for highlighting relevant parts of types in [`Self::context()`].
-    // FIXME: rename?
-    pub fn location(&self) -> &[ErrorLocation] {
-        &self.location
+    pub fn path(&self) -> &[ErrorPathFragment] {
+        &self.path
     }
 }
 

--- a/typing/src/error/mod.rs
+++ b/typing/src/error/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     visit::VisitMut,
     PrimitiveType, Tuple, Type,
 };
-use arithmetic_parser::{Spanned, UnsupportedType};
+use arithmetic_parser::{Location, Spanned, UnsupportedType};
 
 mod kind;
 mod location;
@@ -21,92 +21,95 @@ pub use self::{
 };
 
 /// Type error together with the corresponding code span.
-// TODO: implement `StripCode`?
 #[derive(Debug, Clone)]
-pub struct Error<'a, Prim: PrimitiveType> {
-    inner: Spanned<'a, ErrorKind<Prim>>,
-    root_span: Spanned<'a>,
+pub struct Error<Prim: PrimitiveType> {
+    inner: Location<ErrorKind<Prim>>,
+    root_location: Location,
     context: ErrorContext<Prim>,
     location: Vec<ErrorLocation>,
 }
 
-impl<Prim: PrimitiveType> fmt::Display for Error<'_, Prim> {
+impl<Prim: PrimitiveType> fmt::Display for Error<Prim> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
             "{}:{}: {}",
-            self.main_span().location_line(),
-            self.main_span().get_column(),
+            self.main_location().location_line(),
+            self.main_location().get_column(),
             self.kind()
         )
     }
 }
 
-impl<Prim: PrimitiveType> std::error::Error for Error<'_, Prim> {
+impl<Prim: PrimitiveType> std::error::Error for Error<Prim> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.kind())
     }
 }
 
-impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
+impl<Prim: PrimitiveType> Error<Prim> {
     pub(crate) fn unsupported<T>(
         unsupported: impl Into<UnsupportedType>,
-        span: &Spanned<'a, T>,
+        span: &Spanned<'_, T>,
     ) -> Self {
         let kind = ErrorKind::unsupported(unsupported);
         Self {
-            inner: span.copy_with_extra(kind),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(kind).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
             location: vec![],
         }
     }
 
-    pub(crate) fn undefined_var<T>(span: &Spanned<'a, T>) -> Self {
+    pub(crate) fn undefined_var<T>(span: &Spanned<'_, T>) -> Self {
         let ident = (*span.fragment()).to_owned();
         Self {
-            inner: span.copy_with_extra(ErrorKind::UndefinedVar(ident)),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(ErrorKind::UndefinedVar(ident)).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
             location: vec![],
         }
     }
 
-    pub(crate) fn repeated_assignment(span: Spanned<'a>) -> Self {
+    pub(crate) fn repeated_assignment(span: Spanned<'_>) -> Self {
         let ident = (*span.fragment()).to_owned();
         Self {
-            inner: span.copy_with_extra(ErrorKind::RepeatedAssignment(ident)),
-            root_span: span.with_no_extra(),
+            inner: span
+                .copy_with_extra(ErrorKind::RepeatedAssignment(ident))
+                .into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
             location: vec![],
         }
     }
 
-    pub(crate) fn repeated_field(span: Spanned<'a>) -> Self {
+    pub(crate) fn repeated_field(span: Spanned<'_>) -> Self {
         let ident = (*span.fragment()).to_owned();
         Self {
-            inner: span.copy_with_extra(ErrorKind::RepeatedField(ident)),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(ErrorKind::RepeatedField(ident)).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
             location: vec![],
         }
     }
 
-    pub(crate) fn conversion<T>(kind: AstConversionError, span: &Spanned<'a, T>) -> Self {
+    pub(crate) fn conversion<T>(kind: AstConversionError, span: &Spanned<'_, T>) -> Self {
         let kind = ErrorKind::AstConversion(kind);
         Self {
-            inner: span.copy_with_extra(kind),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(kind).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::None,
             location: vec![],
         }
     }
 
-    pub(crate) fn invalid_field_name(span: Spanned<'a>) -> Self {
+    pub(crate) fn invalid_field_name(span: Spanned<'_>) -> Self {
         let ident = (*span.fragment()).to_owned();
         Self {
-            inner: span.copy_with_extra(ErrorKind::InvalidFieldName(ident)),
-            root_span: span,
+            inner: span
+                .copy_with_extra(ErrorKind::InvalidFieldName(ident))
+                .into(),
+            root_location: span.into(),
             context: ErrorContext::None,
             location: vec![],
         }
@@ -114,15 +117,17 @@ impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
 
     pub(crate) fn index_out_of_bounds<T>(
         receiver: Tuple<Prim>,
-        span: &Spanned<'a, T>,
+        span: &Spanned<'_, T>,
         index: usize,
     ) -> Self {
         Self {
-            inner: span.copy_with_extra(ErrorKind::IndexOutOfBounds {
-                index,
-                len: receiver.len(),
-            }),
-            root_span: span.with_no_extra(),
+            inner: span
+                .copy_with_extra(ErrorKind::IndexOutOfBounds {
+                    index,
+                    len: receiver.len(),
+                })
+                .into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::TupleIndex {
                 ty: Type::Tuple(receiver),
             },
@@ -130,19 +135,19 @@ impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
         }
     }
 
-    pub(crate) fn cannot_index<T>(receiver: Type<Prim>, span: &Spanned<'a, T>) -> Self {
+    pub(crate) fn cannot_index<T>(receiver: Type<Prim>, span: &Spanned<'_, T>) -> Self {
         Self {
-            inner: span.copy_with_extra(ErrorKind::CannotIndex),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(ErrorKind::CannotIndex).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::TupleIndex { ty: receiver },
             location: vec![],
         }
     }
 
-    pub(crate) fn unsupported_index<T>(receiver: Type<Prim>, span: &Spanned<'a, T>) -> Self {
+    pub(crate) fn unsupported_index<T>(receiver: Type<Prim>, span: &Spanned<'_, T>) -> Self {
         Self {
-            inner: span.copy_with_extra(ErrorKind::UnsupportedIndex),
-            root_span: span.with_no_extra(),
+            inner: span.copy_with_extra(ErrorKind::UnsupportedIndex).into(),
+            root_location: span.with_no_extra().into(),
             context: ErrorContext::TupleIndex { ty: receiver },
             location: vec![],
         }
@@ -154,13 +159,13 @@ impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
     }
 
     /// Gets the most specific code span of this error.
-    pub fn main_span(&self) -> Spanned<'a> {
+    pub fn main_location(&self) -> Location {
         self.inner.with_no_extra()
     }
 
-    /// Gets the root code span of the failed operation. May coincide with [`Self::main_span()`].
-    pub fn root_span(&self) -> Spanned<'a> {
-        self.root_span
+    /// Gets the root code location of the failed operation. May coincide with [`Self::main_location()`].
+    pub fn root_location(&self) -> Location {
+        self.root_location
     }
 
     /// Gets the context for an operation that has failed.
@@ -170,6 +175,7 @@ impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
 
     /// Gets the location of this error relative to the failed top-level operation.
     /// This can be used for highlighting relevant parts of types in [`Self::context()`].
+    // FIXME: rename?
     pub fn location(&self) -> &[ErrorLocation] {
         &self.location
     }
@@ -204,12 +210,12 @@ impl<'a, Prim: PrimitiveType> Error<'a, Prim> {
 /// # }
 /// ```
 #[derive(Debug, Clone)]
-pub struct Errors<'a, Prim: PrimitiveType> {
-    inner: Vec<Error<'a, Prim>>,
+pub struct Errors<Prim: PrimitiveType> {
+    inner: Vec<Error<Prim>>,
     first_failing_statement: usize,
 }
 
-impl<'a, Prim: PrimitiveType> Errors<'a, Prim> {
+impl<Prim: PrimitiveType> Errors<Prim> {
     pub(crate) fn new() -> Self {
         Self {
             inner: vec![],
@@ -217,11 +223,11 @@ impl<'a, Prim: PrimitiveType> Errors<'a, Prim> {
         }
     }
 
-    pub(crate) fn push(&mut self, err: Error<'a, Prim>) {
+    pub(crate) fn push(&mut self, err: Error<Prim>) {
         self.inner.push(err);
     }
 
-    pub(crate) fn extend(&mut self, errors: Vec<Error<'a, Prim>>) {
+    pub(crate) fn extend(&mut self, errors: Vec<Error<Prim>>) {
         self.inner.extend(errors);
     }
 
@@ -236,7 +242,7 @@ impl<'a, Prim: PrimitiveType> Errors<'a, Prim> {
     }
 
     /// Iterates over errors contained in this list.
-    pub fn iter(&self) -> impl Iterator<Item = &Error<'a, Prim>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &Error<Prim>> + '_ {
         self.inner.iter()
     }
 
@@ -260,7 +266,7 @@ impl<'a, Prim: PrimitiveType> Errors<'a, Prim> {
     }
 }
 
-impl<Prim: PrimitiveType> fmt::Display for Errors<'_, Prim> {
+impl<Prim: PrimitiveType> fmt::Display for Errors<Prim> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, error) in self.inner.iter().enumerate() {
             write!(formatter, "{error}")?;
@@ -272,10 +278,10 @@ impl<Prim: PrimitiveType> fmt::Display for Errors<'_, Prim> {
     }
 }
 
-impl<Prim: PrimitiveType> std::error::Error for Errors<'_, Prim> {}
+impl<Prim: PrimitiveType> std::error::Error for Errors<Prim> {}
 
-impl<'a, Prim: PrimitiveType> IntoIterator for Errors<'a, Prim> {
-    type Item = Error<'a, Prim>;
+impl<Prim: PrimitiveType> IntoIterator for Errors<Prim> {
+    type Item = Error<Prim>;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/typing/src/types/mod.rs
+++ b/typing/src/types/mod.rs
@@ -162,7 +162,7 @@ impl TypeVar {
 /// let errors = env.process_statements(&ast).unwrap_err();
 /// # assert_eq!(errors.len(), 1);
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_span().fragment(), "x(1)");
+/// assert_eq!(*err.main_location().fragment(), "x(1)");
 /// # Ok(())
 /// # }
 /// ```
@@ -421,7 +421,7 @@ impl<Prim: PrimitiveType> Type<Prim> {
 /// let errors = env.process_statements(&ast).unwrap_err();
 ///
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_span().fragment(), "true");
+/// assert_eq!(*err.main_location().fragment(), "true");
 /// assert_matches!(err.kind(), ErrorKind::FailedConstraint { .. });
 /// # Ok(())
 /// # }

--- a/typing/src/types/mod.rs
+++ b/typing/src/types/mod.rs
@@ -133,7 +133,7 @@ impl TypeVar {
 /// # `Any` type
 ///
 /// [`Self::Any`], denoted as `any`, is a catch-all type similar to `any` in TypeScript.
-/// It allows to circumvent type system limitations at the cost of being exteremely imprecise.
+/// It allows to circumvent type system limitations at the cost of being extremely imprecise.
 /// `any` type can be used in any context (destructured, called with args of any quantity
 /// and type and so on), with each application of the type evaluated independently.
 /// Thus, the same `any` variable can be treated as a function, a tuple, a primitive type, etc.
@@ -162,7 +162,7 @@ impl TypeVar {
 /// let errors = env.process_statements(&ast).unwrap_err();
 /// # assert_eq!(errors.len(), 1);
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_location().fragment(), "x(1)");
+/// assert_eq!(err.main_location().span(bogus_code), "x(1)");
 /// # Ok(())
 /// # }
 /// ```
@@ -421,7 +421,7 @@ impl<Prim: PrimitiveType> Type<Prim> {
 /// let errors = env.process_statements(&ast).unwrap_err();
 ///
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_location().fragment(), "true");
+/// assert_eq!(err.main_location().span(code), "true");
 /// assert_matches!(err.kind(), ErrorKind::FailedConstraint { .. });
 /// # Ok(())
 /// # }

--- a/typing/src/types/object.rs
+++ b/typing/src/types/object.rs
@@ -182,7 +182,7 @@ impl<Prim: PrimitiveType> Object<Prim> {
     ) {
         for (field_name, ty) in other.fields {
             if let Some(this_field) = self.fields.get(&field_name) {
-                substitutions.unify(this_field, &ty, errors.with_location(field_name.as_str()));
+                substitutions.unify(this_field, &ty, errors.join_path(field_name.as_str()));
             } else {
                 self.fields.insert(field_name, ty);
             }
@@ -229,7 +229,7 @@ impl<Prim: PrimitiveType> Object<Prim> {
         let mut missing_fields = HashSet::new();
         for (field_name, lhs_ty) in self.iter() {
             if let Some(rhs_ty) = rhs.get(field_name) {
-                substitutions.unify(lhs_ty, rhs_ty, errors.with_location(field_name));
+                substitutions.unify(lhs_ty, rhs_ty, errors.join_path(field_name));
             } else {
                 missing_fields.insert(field_name.to_owned());
             }

--- a/typing/src/types/tuple.rs
+++ b/typing/src/types/tuple.rs
@@ -605,16 +605,17 @@ pub(crate) enum IndexError {
 /// // Slices with fixed length are equivalent to tuples.
 /// assert_eq!(env["xs"].to_string(), "(Num, Num, Num)");
 ///
-/// let ast = Parser::parse_statements(r#"
+/// let code = r#"
 ///     xs: [Num] = (1, 2, 3);
 ///     ys = xs + 1; // works fine: despite `xs` having unknown length,
 ///                  // it's always possible to add a number to it
 ///     (_, _, z) = xs; // does not work: the tuple length is erased
-/// "#)?;
+/// "#;
+/// let ast = Parser::parse_statements(code)?;
 /// let errors = env.process_statements(&ast).unwrap_err();
 ///
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_location().fragment(), "(_, _, z)");
+/// assert_eq!(err.main_location().span(code), "(_, _, z)");
 /// assert_eq!(env["ys"], env["xs"]);
 /// # Ok(())
 /// # }

--- a/typing/src/types/tuple.rs
+++ b/typing/src/types/tuple.rs
@@ -614,7 +614,7 @@ pub(crate) enum IndexError {
 /// let errors = env.process_statements(&ast).unwrap_err();
 ///
 /// let err = errors.iter().next().unwrap();
-/// assert_eq!(*err.main_span().fragment(), "(_, _, z)");
+/// assert_eq!(*err.main_location().fragment(), "(_, _, z)");
 /// assert_eq!(env["ys"], env["xs"]);
 /// # Ok(())
 /// # }

--- a/typing/tests/integration/annotations.rs
+++ b/typing/tests/integration/annotations.rs
@@ -219,7 +219,7 @@ fn unifying_tuples_with_dyn_lengths() {
     type_env.insert("true", Type::BOOL);
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "(...[_; _], _, Num)");
+    assert_eq!(err.main_location().span(code), "(...[_; _], _, Num)");
     assert_eq!(err.location(), [ErrorLocation::TupleElement(None)]);
     assert_matches!(
         err.context(),
@@ -274,7 +274,7 @@ fn type_with_tuple_of_any() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "test(1)");
+    assert_eq!(err.main_location().span(code), "test(1)");
     assert_matches!(
         err.kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
@@ -296,7 +296,7 @@ fn type_with_any_fn() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "fun(1, 2)");
+    assert_eq!(err.main_location().span(code), "fun(1, 2)");
     assert_matches!(
         err.kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }
@@ -315,7 +315,7 @@ fn dyn_type_in_slice() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "[dyn Lin; _]");
+    assert_eq!(err.main_location().span(code), "[dyn Lin; _]");
     assert_matches!(
         err.kind(),
         ErrorKind::FailedConstraint { ty, .. } if *ty == Type::BOOL
@@ -461,7 +461,7 @@ fn annotations_for_fns_with_slices() {
     type_env.insert("map", Prelude::Map);
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(err.main_span().location_line(), 4);
+    assert_eq!(err.main_location().location_line(), 4);
     assert_matches!(
         err.kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }

--- a/typing/tests/integration/annotations.rs
+++ b/typing/tests/integration/annotations.rs
@@ -5,7 +5,7 @@ use assert_matches::assert_matches;
 use arithmetic_parser::grammars::Parse;
 use arithmetic_typing::{
     defs::Prelude,
-    error::{ErrorContext, ErrorKind, ErrorLocation},
+    error::{ErrorContext, ErrorKind, ErrorPathFragment},
     TupleLen, Type, TypeEnvironment, UnknownLen,
 };
 
@@ -220,7 +220,7 @@ fn unifying_tuples_with_dyn_lengths() {
     let err = type_env.process_statements(&block).unwrap_err().single();
 
     assert_eq!(err.main_location().span(code), "(...[_; _], _, Num)");
-    assert_eq!(err.location(), [ErrorLocation::TupleElement(None)]);
+    assert_eq!(err.path(), [ErrorPathFragment::TupleElement(None)]);
     assert_matches!(
         err.context(),
         ErrorContext::Assignment { lhs, rhs }

--- a/typing/tests/integration/basics.rs
+++ b/typing/tests/integration/basics.rs
@@ -8,7 +8,7 @@ use arithmetic_parser::grammars::Parse;
 use arithmetic_typing::{
     arith::{Num, NumArithmetic},
     defs::Prelude,
-    error::{ErrorContext, ErrorKind, ErrorLocation},
+    error::{ErrorContext, ErrorKind, ErrorPathFragment},
     Function, TupleLen, Type, TypeEnvironment, UnknownLen,
 };
 
@@ -682,7 +682,7 @@ fn comparison_type_errors() {
         .single();
 
     assert_eq!(err.main_location().span(code), "(2 <= 1)");
-    assert_eq!(err.location(), [ErrorLocation::Lhs]);
+    assert_eq!(err.path(), [ErrorPathFragment::Lhs]);
     assert_matches!(err.context(), ErrorContext::BinaryOp(_));
     assert_matches!(
         err.kind(),

--- a/typing/tests/integration/basics.rs
+++ b/typing/tests/integration/basics.rs
@@ -681,7 +681,7 @@ fn comparison_type_errors() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "(2 <= 1)");
+    assert_eq!(err.main_location().span(code), "(2 <= 1)");
     assert_eq!(err.location(), [ErrorLocation::Lhs]);
     assert_matches!(err.context(), ErrorContext::BinaryOp(_));
     assert_matches!(

--- a/typing/tests/integration/errors/annotations.rs
+++ b/typing/tests/integration/errors/annotations.rs
@@ -202,7 +202,7 @@ fn unsupported_type_param_in_generic_fn() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert!(err.location().is_empty());
+    assert!(err.path().is_empty());
     assert_matches!(err.context(), ErrorContext::Assignment { .. });
     assert_eq!(err.main_location().span(code), "(('Arg,)) -> ('Arg,)");
     assert_matches!(err.kind(), ErrorKind::UnsupportedParam);
@@ -220,7 +220,7 @@ fn unsupported_type_param_location() {
         let mut type_env = TypeEnvironment::new();
         let err = type_env.process_statements(&block).unwrap_err().single();
 
-        assert_eq!(err.location(), [tuple_element(1)]);
+        assert_eq!(err.path(), [tuple_element(1)]);
         assert_matches!(err.context(), ErrorContext::Assignment { .. });
         assert_eq!(err.main_location().span(code), "(('Arg,)) -> ('Arg,)");
         assert_matches!(err.kind(), ErrorKind::UnsupportedParam);
@@ -364,7 +364,7 @@ fn type_cast_error_in_subtype() {
         ErrorKind::FailedConstraint { constraint, .. } if constraint.to_string() == "Lin"
     );
     assert_matches!(err.context(), ErrorContext::TypeCast { .. });
-    assert_eq!(err.location(), [tuple_element(1)]);
+    assert_eq!(err.path(), [tuple_element(1)]);
     assert_eq!(err.main_location().span(code), "|x: Num| x + 3");
 }
 
@@ -483,7 +483,7 @@ fn contradicting_constraint_with_dyn_object() {
         .single();
 
     assert_eq!(err.main_location().span(code), "#{ x: 1 }");
-    assert_eq!(err.location(), [fn_arg(0)]);
+    assert_eq!(err.path(), [fn_arg(0)]);
     assert_matches!(
         err.kind(),
         ErrorKind::FailedConstraint { ty: Type::Dyn(_), constraint }
@@ -503,7 +503,7 @@ fn extra_fields_in_dyn_fn_arg() {
         .single();
 
     assert_eq!(err.main_location().span(code), "|obj| obj.x + obj.y");
-    assert_eq!(err.location(), [fn_arg(1), fn_arg(0)]);
+    assert_eq!(err.path(), [fn_arg(1), fn_arg(0)]);
     assert_matches!(
         err.kind(),
         ErrorKind::MissingFields { fields, .. } if fields.contains("y")

--- a/typing/tests/integration/errors/annotations.rs
+++ b/typing/tests/integration/errors/annotations.rs
@@ -24,7 +24,7 @@ fn converting_fn_type_unused_type() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(err.main_span().location_offset(), 5);
+    assert_eq!(err.main_location().location_offset(), 5);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::UnusedTypeParam(name)) if name == "T"
@@ -37,7 +37,7 @@ fn converting_fn_type_unused_length() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(err.main_span().location_offset(), 9);
+    assert_eq!(err.main_location().location_offset(), 9);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::UnusedLength(name)) if name == "N"
@@ -50,7 +50,7 @@ fn converting_fn_type_free_type_param() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(err.main_span().location_offset(), 6);
+    assert_eq!(err.main_location().location_offset(), 6);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::FreeTypeVar(name)) if name == "T"
@@ -63,7 +63,7 @@ fn converting_fn_type_free_length() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(err.main_span().location_offset(), 6);
+    assert_eq!(err.main_location().location_offset(), 6);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::FreeLengthVar(name)) if name == "N"
@@ -76,7 +76,7 @@ fn converting_fn_type_invalid_constraint() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "Bug");
+    assert_eq!(err.main_location().span(&input), "Bug");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::UnknownConstraint(id))
@@ -90,8 +90,8 @@ fn embedded_type_with_constraints() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "for<'U: Lin>");
-    assert_eq!(err.main_span().location_offset(), 5);
+    assert_eq!(err.main_location().span(&input), "for<'U: Lin>");
+    assert_eq!(err.main_location().location_offset(), 5);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::EmbeddedQuantifier)
@@ -104,8 +104,8 @@ fn object_type_with_duplicate_fields() {
     let (_, ast) = TypeAst::parse(input).unwrap();
     let err = <Type>::try_from(&ast).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 10);
+    assert_eq!(err.main_location().span(&input), "x");
+    assert_eq!(err.main_location().location_offset(), 10);
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::DuplicateField(field))
@@ -115,10 +115,11 @@ fn object_type_with_duplicate_fields() {
 
 #[test]
 fn error_when_parsing_standalone_some_type() {
-    let errors = <Type>::try_from(&TypeAst::try_from("(_) -> Num").unwrap()).unwrap_err();
+    let code = "(_) -> Num";
+    let errors = <Type>::try_from(&TypeAst::try_from(code).unwrap()).unwrap_err();
     let err = errors.single();
 
-    assert_eq!(*err.main_span().fragment(), "_");
+    assert_eq!(err.main_location().span(code), "_");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::InvalidSomeType)
@@ -127,10 +128,11 @@ fn error_when_parsing_standalone_some_type() {
 
 #[test]
 fn error_when_parsing_standalone_some_length() {
-    let errors = <Type>::try_from(&TypeAst::try_from("[Num; _]").unwrap()).unwrap_err();
+    let code = "[Num; _]";
+    let errors = <Type>::try_from(&TypeAst::try_from(code).unwrap()).unwrap_err();
     let err = errors.single();
 
-    assert_eq!(*err.main_span().fragment(), "_");
+    assert_eq!(err.main_location().span(code), "_");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::InvalidSomeLength)
@@ -202,7 +204,7 @@ fn unsupported_type_param_in_generic_fn() {
 
     assert!(err.location().is_empty());
     assert_matches!(err.context(), ErrorContext::Assignment { .. });
-    assert_eq!(*err.main_span().fragment(), "(('Arg,)) -> ('Arg,)");
+    assert_eq!(err.main_location().span(code), "(('Arg,)) -> ('Arg,)");
     assert_matches!(err.kind(), ErrorKind::UnsupportedParam);
 }
 
@@ -220,7 +222,7 @@ fn unsupported_type_param_location() {
 
         assert_eq!(err.location(), [tuple_element(1)]);
         assert_matches!(err.context(), ErrorContext::Assignment { .. });
-        assert_eq!(*err.main_span().fragment(), "(('Arg,)) -> ('Arg,)");
+        assert_eq!(err.main_location().span(code), "(('Arg,)) -> ('Arg,)");
         assert_matches!(err.kind(), ErrorKind::UnsupportedParam);
     }
 }
@@ -232,7 +234,7 @@ fn unsupported_const_param_in_generic_fn() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "([Num; N]) -> [Num; N]");
+    assert_eq!(err.main_location().span(code), "([Num; N]) -> [Num; N]");
     assert_matches!(err.kind(), ErrorKind::UnsupportedParam);
 }
 
@@ -253,9 +255,9 @@ fn adding_dynamically_typed_slices() {
         .collect();
 
     assert_eq!(errors.len(), 2);
-    assert_eq!(*errors[0].main_span().fragment(), "x");
+    assert_eq!(errors[0].main_location().span(code), "x");
     assert_matches!(errors[0].kind(), ErrorKind::DynamicLen(_));
-    assert_eq!(*errors[1].main_span().fragment(), "y");
+    assert_eq!(errors[1].main_location().span(code), "y");
     assert_matches!(errors[1].kind(), ErrorKind::DynamicLen(_));
 }
 
@@ -287,7 +289,7 @@ fn bogus_annotation_in_fn_definition() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "Bogus");
+    assert_eq!(err.main_location().span(code), "Bogus");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::UnknownType(ty))
@@ -304,7 +306,7 @@ fn custom_constraint_if_not_added_to_env() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "Hash");
+    assert_eq!(err.main_location().span(code), "Hash");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::UnknownConstraint(c))
@@ -322,7 +324,7 @@ fn custom_constraint_if_incorrectly_added_to_env() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "Hash");
+    assert_eq!(err.main_location().span(code), "Hash");
     assert_matches!(
         err.kind(),
         ErrorKind::AstConversion(AstConversionError::NotObjectSafe(c))
@@ -337,8 +339,8 @@ fn type_cast_basic_error() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "(1, 2)");
-    assert_eq!(*err.root_span().fragment(), "(1, 2) as Num");
+    assert_eq!(err.main_location().span(code), "(1, 2)");
+    assert_eq!(err.root_location().span(code), "(1, 2) as Num");
     assert_matches!(
         err.kind(),
         ErrorKind::TypeMismatch(lhs, rhs) if *lhs == Type::NUM && rhs.to_string() == "(Num, Num)"
@@ -363,7 +365,7 @@ fn type_cast_error_in_subtype() {
     );
     assert_matches!(err.context(), ErrorContext::TypeCast { .. });
     assert_eq!(err.location(), [tuple_element(1)]);
-    assert_eq!(*err.main_span().fragment(), "|x: Num| x + 3");
+    assert_eq!(err.main_location().span(code), "|x: Num| x + 3");
 }
 
 #[test]
@@ -373,7 +375,7 @@ fn insufficient_info_when_indexing_tuple() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "xs.0");
+    assert_eq!(err.main_location().span(code), "xs.0");
     assert_matches!(err.kind(), ErrorKind::UnsupportedIndex);
     assert_matches!(err.context(), ErrorContext::TupleIndex { ty } if ty.to_string() == "[Num]");
 }
@@ -445,7 +447,7 @@ fn contradicting_dyn_constraint_via_field_access() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "!obj.x");
+    assert_eq!(err.main_location().span(code), "!obj.x");
     assert_matches!(err.context(), ErrorContext::UnaryOp(_));
     assert_matches!(err.kind(), ErrorKind::FailedConstraint { ty, .. } if *ty == Type::BOOL);
 }
@@ -461,7 +463,7 @@ fn contradicting_field_types_via_annotations() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "!obj.x");
+    assert_eq!(err.main_location().span(code), "!obj.x");
     assert_matches!(err.context(), ErrorContext::UnaryOp(_));
     assert_matches!(
         err.kind(),
@@ -480,7 +482,7 @@ fn contradicting_constraint_with_dyn_object() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "#{ x: 1 }");
+    assert_eq!(err.main_location().span(code), "#{ x: 1 }");
     assert_eq!(err.location(), [fn_arg(0)]);
     assert_matches!(
         err.kind(),
@@ -500,7 +502,7 @@ fn extra_fields_in_dyn_fn_arg() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "|obj| obj.x + obj.y");
+    assert_eq!(err.main_location().span(code), "|obj| obj.x + obj.y");
     assert_eq!(err.location(), [fn_arg(1), fn_arg(0)]);
     assert_matches!(
         err.kind(),

--- a/typing/tests/integration/errors/mod.rs
+++ b/typing/tests/integration/errors/mod.rs
@@ -32,7 +32,7 @@ fn type_recursion() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "x + (x, 2)");
+    assert_eq!(err.main_location().span(code), "x + (x, 2)");
     assert!(err.location().is_empty());
     assert_matches!(err.context(), ErrorContext::BinaryOp(_));
     assert_matches!(
@@ -80,7 +80,7 @@ fn unknown_method() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "do_something");
+    assert_eq!(err.main_location().span(code), "do_something");
     assert!(err.location().is_empty());
     assert_matches!(err.context(), ErrorContext::None);
     assert_matches!(err.kind(), ErrorKind::UndefinedVar(name) if name == "do_something");
@@ -97,7 +97,7 @@ fn immediately_invoked_function_with_invalid_arg() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "4 == 7");
+    assert_eq!(err.main_location().span(code), "4 == 7");
     assert_eq!(err.location(), [fn_arg(0)]);
     assert_matches!(
         err.context(),
@@ -119,7 +119,7 @@ fn destructuring_error_on_assignment() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "(x, y, ...zs)");
+    assert_eq!(err.main_location().span(bogus_code), "(x, y, ...zs)");
     assert!(err.location().is_empty());
     assert_matches!(
         err.context(),
@@ -201,7 +201,7 @@ fn function_passed_as_arg_invalid_arity() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "|x, y| x + y");
+    assert_eq!(err.main_location().span(code), "|x, y| x + y");
     assert_eq!(err.location(), [fn_arg(1)]);
     let expected_call_signature = "((Num, Num), for<'T: Ops> ('T, 'T) -> 'T) -> (Num, Num)";
     assert_matches!(
@@ -252,7 +252,7 @@ fn function_passed_as_arg_invalid_input() {
     let mut type_env = TypeEnvironment::new();
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "2 != 3");
+    assert_eq!(err.main_location().span(code), "2 != 3");
     assert_eq!(err.location(), [fn_arg(0), tuple_element(1)]);
     assert_matches!(
         err.context(),
@@ -276,7 +276,7 @@ fn incorrect_arg_in_slices() {
 
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "2 == 3");
+    assert_eq!(err.main_location().span(code), "2 == 3");
     assert_eq!(err.location(), [fn_arg(0), tuple_element(1)]);
     assert_matches!(
         err.context(),
@@ -295,7 +295,7 @@ fn unifying_length_vars_error() {
     type_env.insert("zip_with", zip_fn_type());
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "(3, 4, 5)");
+    assert_eq!(err.main_location().span(code), "(3, 4, 5)");
     assert_eq!(err.location(), [fn_arg(1)]);
     assert_matches!(
         err.context(),
@@ -336,7 +336,7 @@ fn comparisons_when_switched_off() {
     type_env.insert("filter", Prelude::Filter);
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "x > 1");
+    assert_eq!(err.main_location().span(code), "x > 1");
     assert!(err.location().is_empty());
     assert_matches!(err.context(), ErrorContext::BinaryOp(_));
     assert_matches!(err.kind(), ErrorKind::UnsupportedFeature(_));
@@ -356,7 +356,7 @@ fn constraint_error() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "1 == 2");
+    assert_eq!(err.main_location().span(code), "1 == 2");
     assert_matches!(
         err.kind(),
         ErrorKind::FailedConstraint { ty, constraint }
@@ -376,7 +376,7 @@ fn dyn_type_with_bogus_function_call() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "|x| x + 1");
+    assert_eq!(err.main_location().span(code), "|x| x + 1");
     assert_eq!(err.location(), [fn_arg(1)]);
     assert_matches!(
         err.context(),
@@ -419,7 +419,7 @@ fn locating_type_with_failed_constraint() {
             .unwrap_err()
             .single();
 
-        assert_eq!(*err.main_span().fragment(), "true");
+        assert_eq!(err.main_location().span(code), "true");
         assert_eq!(err.location()[1..], [tuple_element(1)]);
         assert_matches!(err.context(), ErrorContext::BinaryOp(_));
         assert_matches!(err.kind(), ErrorKind::FailedConstraint { .. });
@@ -437,8 +437,8 @@ fn locating_tuple_middle_with_failed_constraint() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "xs");
-    assert_eq!(*err.root_span().fragment(), "xs + 1");
+    assert_eq!(err.main_location().span(code), "xs");
+    assert_eq!(err.root_location().span(code), "xs + 1");
     assert_eq!(
         err.location(),
         [ErrorLocation::Lhs, TupleIndex::Middle.into()]
@@ -461,7 +461,7 @@ fn invalid_field_name() {
         .single();
 
     assert_eq!(
-        *err.main_span().fragment(),
+        err.main_location().span(code),
         "123456789012345678901234567890"
     );
     assert_eq!(err.location(), []);
@@ -486,7 +486,7 @@ fn indexing_hard_errors() {
     let mut errors = errors.into_iter();
 
     let block_err = errors.next().unwrap();
-    assert_eq!(*block_err.main_span().fragment(), "{ 5 }.1");
+    assert_eq!(block_err.main_location().span(code), "{ 5 }.1");
     assert_eq!(block_err.location(), []);
     assert_matches!(
         block_err.context(),
@@ -495,11 +495,11 @@ fn indexing_hard_errors() {
     assert_matches!(block_err.kind(), ErrorKind::CannotIndex);
 
     let fn_err = errors.next().unwrap();
-    assert_eq!(*fn_err.main_span().fragment(), "(|x| x + 1).0");
+    assert_eq!(fn_err.main_location().span(code), "(|x| x + 1).0");
     assert_matches!(fn_err.kind(), ErrorKind::CannotIndex);
 
     let oob_err = errors.next().unwrap();
-    assert_eq!(*oob_err.main_span().fragment(), "xs.2");
+    assert_eq!(oob_err.main_location().span(code), "xs.2");
     assert_matches!(
         oob_err.kind(),
         ErrorKind::IndexOutOfBounds { index, len } if *index == 2 && *len == TupleLen::from(2)
@@ -516,7 +516,7 @@ fn overly_large_indexed_field() {
         .single();
 
     assert_eq!(
-        *err.main_span().fragment(),
+        err.main_location().span(code),
         "123456789012345678901234567890"
     );
     assert_matches!(
@@ -534,7 +534,7 @@ fn indexing_unsupported_errors() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "xs.0");
+    assert_eq!(err.main_location().span(code), "xs.0");
     assert_eq!(err.location(), []);
     assert_matches!(err.context(), ErrorContext::TupleIndex { ty: Type::Var(_) });
     assert_matches!(err.kind(), ErrorKind::UnsupportedIndex);
@@ -549,8 +549,8 @@ fn multiple_var_assignments() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 4);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 4);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment(var) if var == "x");
 }
 
@@ -563,8 +563,8 @@ fn multiple_var_assignments_in_fn_def() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 4);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 4);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment(var) if var == "x");
 }
 
@@ -577,8 +577,8 @@ fn multiple_var_assignments_complex() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 6);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 6);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment(var) if var == "x");
 }
 
@@ -591,7 +591,7 @@ fn multiple_var_assignments_in_fn_def_complex() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 13);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 13);
     assert_matches!(err.kind(), ErrorKind::RepeatedAssignment(var) if var == "x");
 }

--- a/typing/tests/integration/errors/multiple.rs
+++ b/typing/tests/integration/errors/multiple.rs
@@ -16,26 +16,26 @@ fn multiple_independent_errors() {
         (1, 2).filter(|x| x + 1);
         (1, false).map(6);
     "#;
-    let code = F32Grammar::parse_statements(code).unwrap();
+    let block = F32Grammar::parse_statements(code).unwrap();
     let mut type_env: TypeEnvironment = Prelude::iter().collect();
     let errors: Vec<_> = type_env
-        .process_statements(&code)
+        .process_statements(&block)
         .unwrap_err()
         .into_iter()
         .collect();
 
     assert_eq!(errors.len(), 4);
 
-    assert_eq!(*errors[0].main_span().fragment(), "true");
+    assert_eq!(errors[0].main_location().span(code), "true");
     assert_matches!(
         errors[0].kind(),
         ErrorKind::FailedConstraint { ty, constraint }
             if *ty == Type::BOOL && constraint.to_string() == "Ops"
     );
 
-    assert_eq!(*errors[1].main_span().fragment(), "|x| x + 1");
+    assert_eq!(errors[1].main_location().span(code), "|x| x + 1");
     assert_eq!(
-        *errors[1].root_span().fragment(),
+        errors[1].root_location().span(code),
         "(1, 2).filter(|x| x + 1)"
     );
     assert_matches!(
@@ -44,16 +44,16 @@ fn multiple_independent_errors() {
             if *lhs == Type::BOOL && *rhs == Type::NUM
     );
 
-    assert_eq!(*errors[2].main_span().fragment(), "false");
-    assert_eq!(*errors[2].root_span().fragment(), "(1, false).map(6)");
+    assert_eq!(errors[2].main_location().span(code), "false");
+    assert_eq!(errors[2].root_location().span(code), "(1, false).map(6)");
     assert_matches!(
         errors[2].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
             if *lhs == Type::NUM && *rhs == Type::BOOL
     );
 
-    assert_eq!(*errors[3].main_span().fragment(), "6");
-    assert_eq!(*errors[3].root_span().fragment(), "(1, false).map(6)");
+    assert_eq!(errors[3].main_location().span(code), "6");
+    assert_eq!(errors[3].root_location().span(code), "(1, false).map(6)");
     assert_matches!(
         errors[3].kind(),
         ErrorKind::TypeMismatch(Type::Function(_), rhs)
@@ -67,33 +67,33 @@ fn recovery_after_error() {
          1 + (x == 3) == 2;
          (x, y, z) = (1, false).map(|x| x + 1) + 3;
     "#;
-    let code = F32Grammar::parse_statements(code).unwrap();
+    let block = F32Grammar::parse_statements(code).unwrap();
 
     let mut type_env: TypeEnvironment = Prelude::iter().collect();
     let errors: Vec<_> = type_env
-        .process_statements(&code)
+        .process_statements(&block)
         .unwrap_err()
         .into_iter()
         .collect();
 
     assert_eq!(errors.len(), 4);
 
-    assert_eq!(*errors[0].main_span().fragment(), "x");
+    assert_eq!(errors[0].main_location().span(code), "x");
     assert_matches!(
         errors[0].kind(),
         ErrorKind::UndefinedVar(id) if id == "x"
     );
 
-    assert_eq!(*errors[1].main_span().fragment(), "(x == 3)");
+    assert_eq!(errors[1].main_location().span(code), "(x == 3)");
     assert_matches!(
         errors[1].kind(),
         ErrorKind::FailedConstraint { ty, constraint }
             if *ty == Type::BOOL && constraint.to_string() == "Ops"
     );
 
-    assert_eq!(*errors[2].main_span().fragment(), "false");
+    assert_eq!(errors[2].main_location().span(code), "false");
     assert_eq!(
-        *errors[2].root_span().fragment(),
+        errors[2].root_location().span(code),
         "(1, false).map(|x| x + 1)"
     );
     assert_matches!(
@@ -102,7 +102,7 @@ fn recovery_after_error() {
             if *lhs == Type::NUM && *rhs == Type::BOOL
     );
 
-    assert_eq!(*errors[3].main_span().fragment(), "(x, y, z)");
+    assert_eq!(errors[3].main_location().span(code), "(x, y, z)");
     assert_matches!(
         errors[3].kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }
@@ -118,35 +118,35 @@ fn recovery_in_fn_definition() {
         bogus(true);
         (1, 2, 3).bogus();
     "#;
-    let code = F32Grammar::parse_statements(code).unwrap();
+    let block = F32Grammar::parse_statements(code).unwrap();
 
     let mut type_env: TypeEnvironment = Prelude::iter().collect();
     let errors: Vec<_> = type_env
-        .process_statements(&code)
+        .process_statements(&block)
         .unwrap_err()
         .into_iter()
         .collect();
 
     assert_eq!(errors.len(), 3);
 
-    assert_eq!(*errors[0].main_span().fragment(), "|x| x + 1");
-    assert_eq!(*errors[0].root_span().fragment(), "xs.filter(|x| x + 1)");
+    assert_eq!(errors[0].main_location().span(code), "|x| x + 1");
+    assert_eq!(errors[0].root_location().span(code), "xs.filter(|x| x + 1)");
     assert_matches!(
         errors[0].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
             if *lhs == Type::BOOL && *rhs == Type::NUM
     );
 
-    assert_eq!(*errors[1].main_span().fragment(), "true");
-    assert_eq!(*errors[1].root_span().fragment(), "bogus(true)");
+    assert_eq!(errors[1].main_location().span(code), "true");
+    assert_eq!(errors[1].root_location().span(code), "bogus(true)");
     assert_matches!(
         errors[1].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
             if *lhs == Type::NUM && *rhs == Type::BOOL
     );
 
-    assert_eq!(*errors[2].main_span().fragment(), "(1, 2, 3)");
-    assert_eq!(*errors[2].root_span().fragment(), "(1, 2, 3).bogus()");
+    assert_eq!(errors[2].main_location().span(code), "(1, 2, 3)");
+    assert_eq!(errors[2].root_location().span(code), "(1, 2, 3).bogus()");
     assert_matches!(
         errors[2].kind(),
         ErrorKind::TypeMismatch(lhs, Type::Tuple(_)) if *lhs == Type::NUM
@@ -159,41 +159,41 @@ fn recovery_in_mangled_fn_definition() {
         bogus = |...xs| xs.filter(|x| x, 1);
         bogus(1, 2) == (3,);
     "#;
-    let code = F32Grammar::parse_statements(code).unwrap();
+    let block = F32Grammar::parse_statements(code).unwrap();
 
     let mut type_env: TypeEnvironment = Prelude::iter().collect();
     let errors: Vec<_> = type_env
-        .process_statements(&code)
+        .process_statements(&block)
         .unwrap_err()
         .into_iter()
         .collect();
 
     assert_eq!(errors.len(), 4);
 
-    assert_eq!(*errors[0].main_span().fragment(), "xs.filter(|x| x, 1)");
+    assert_eq!(errors[0].main_location().span(code), "xs.filter(|x| x, 1)");
     assert_matches!(
         errors[0].kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }
             if *lhs == TupleLen::from(2) && *rhs == TupleLen::from(3)
     );
 
-    assert_eq!(*errors[1].main_span().fragment(), "1");
-    assert_eq!(*errors[1].root_span().fragment(), "bogus(1, 2)");
+    assert_eq!(errors[1].main_location().span(code), "1");
+    assert_eq!(errors[1].root_location().span(code), "bogus(1, 2)");
     assert_matches!(
         errors[1].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
             if *lhs == Type::BOOL && *rhs == Type::NUM
     );
 
-    assert_eq!(*errors[2].main_span().fragment(), "2");
-    assert_eq!(*errors[2].root_span().fragment(), "bogus(1, 2)");
+    assert_eq!(errors[2].main_location().span(code), "2");
+    assert_eq!(errors[2].root_location().span(code), "bogus(1, 2)");
     assert_matches!(
         errors[2].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
             if *lhs == Type::BOOL && *rhs == Type::NUM
     );
 
-    assert_eq!(*errors[3].main_span().fragment(), "bogus(1, 2) == (3,)");
+    assert_eq!(errors[3].main_location().span(code), "bogus(1, 2) == (3,)");
     assert_matches!(
         errors[3].kind(),
         ErrorKind::TypeMismatch(lhs, rhs)
@@ -207,25 +207,25 @@ fn recovery_in_fn_with_insufficient_args() {
         xs = (1, 2, 3).map();
         xs == (false, true);
     "#;
-    let code = F32Grammar::parse_statements(code).unwrap();
+    let block = F32Grammar::parse_statements(code).unwrap();
 
     let mut type_env: TypeEnvironment = Prelude::iter().collect();
     let errors: Vec<_> = type_env
-        .process_statements(&code)
+        .process_statements(&block)
         .unwrap_err()
         .into_iter()
         .collect();
 
     assert_eq!(errors.len(), 2);
 
-    assert_eq!(*errors[0].main_span().fragment(), "(1, 2, 3).map()");
+    assert_eq!(errors[0].main_location().span(code), "(1, 2, 3).map()");
     assert_matches!(
         errors[0].kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }
             if *lhs == TupleLen::from(2) && *rhs == TupleLen::from(1)
     );
 
-    assert_eq!(*errors[1].main_span().fragment(), "xs == (false, true)");
+    assert_eq!(errors[1].main_location().span(code), "xs == (false, true)");
     assert_matches!(
         errors[1].kind(),
         ErrorKind::TupleLenMismatch { lhs, rhs, .. }

--- a/typing/tests/integration/errors/object.rs
+++ b/typing/tests/integration/errors/object.rs
@@ -6,7 +6,7 @@ use arithmetic_parser::grammars::Parse;
 use arithmetic_typing::{
     arith::NumArithmetic,
     defs::Prelude,
-    error::{ErrorContext, ErrorKind, ErrorLocation},
+    error::{ErrorContext, ErrorKind, ErrorPathFragment},
     Type, TypeEnvironment,
 };
 
@@ -121,7 +121,7 @@ fn no_required_field() {
         .single();
 
     assert_eq!(err.main_location().span(code), "#{ y: 2 }");
-    assert_eq!(err.location(), [fn_arg(0)]);
+    assert_eq!(err.path(), [fn_arg(0)]);
     assert_matches!(
         err.kind(),
         ErrorKind::MissingFields { fields, available_fields }
@@ -143,7 +143,7 @@ fn incompatible_field_types() {
         .single();
 
     assert_eq!(err.main_location().span(code), "#{ x: (1, 2) }");
-    assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("x")]);
+    assert_eq!(err.path(), [fn_arg(0), ErrorPathFragment::from("x")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
         err.kind(),
@@ -161,7 +161,7 @@ fn incompatible_field_types_via_accesses() {
         .single();
 
     assert_eq!(err.main_location().span(code), "!obj.x");
-    assert_eq!(err.location(), []);
+    assert_eq!(err.path(), []);
     assert_matches!(err.context(), ErrorContext::UnaryOp(_));
     assert_matches!(
         err.kind(),
@@ -182,7 +182,7 @@ fn incompatible_field_types_via_fn() {
         .single();
 
     assert_eq!(err.main_location().span(code), "obj");
-    assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("x")]);
+    assert_eq!(err.path(), [fn_arg(0), ErrorPathFragment::from("x")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
         err.kind(),
@@ -201,7 +201,7 @@ fn incompatible_fields_via_constraints_for_concrete_object() {
         .single();
 
     assert_eq!(err.main_location().span(code), "#{ x: 1, y: || 2 }");
-    assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("y")]);
+    assert_eq!(err.path(), [fn_arg(0), ErrorPathFragment::from("y")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
         err.kind(),
@@ -221,7 +221,7 @@ fn incompatible_fields_via_constraints_for_object_constraint() {
         .single();
 
     assert_eq!(err.main_location().span(code), "(obj.run)()");
-    assert_eq!(err.location(), []);
+    assert_eq!(err.path(), []);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
         err.kind(),
@@ -241,7 +241,7 @@ fn incompatible_fields_via_constraints_for_object_constraint_rev() {
         .single();
 
     assert_eq!(err.main_location().span(code), "obj");
-    assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("run")]);
+    assert_eq!(err.path(), [fn_arg(0), ErrorPathFragment::from("run")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
         err.kind(),

--- a/typing/tests/integration/errors/object.rs
+++ b/typing/tests/integration/errors/object.rs
@@ -45,7 +45,7 @@ fn tuple_as_object() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "(1, 2)");
+    assert_eq!(err.main_location().span(code), "(1, 2)");
     assert_matches!(err.kind(), ErrorKind::CannotAccessFields);
 }
 
@@ -58,7 +58,7 @@ fn calling_non_function_field() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "{pt.x}()");
+    assert_eq!(err.main_location().span(code), "{pt.x}()");
     assert_matches!(
         err.kind(),
         ErrorKind::TypeMismatch(Type::Function(_), Type::Prim(_))
@@ -74,7 +74,7 @@ fn calling_field_on_non_object() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "array.len");
+    assert_eq!(err.main_location().span(code), "array.len");
     assert_matches!(err.kind(), ErrorKind::CannotAccessFields);
 }
 
@@ -87,7 +87,7 @@ fn object_and_tuple_constraints() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "(x, ...)");
+    assert_eq!(err.main_location().span(code), "(x, ...)");
     assert_matches!(err.kind(), ErrorKind::CannotAccessFields);
 }
 
@@ -100,7 +100,7 @@ fn object_and_tuple_constraints_via_fields() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "obj.0");
+    assert_eq!(err.main_location().span(code), "obj.0");
     assert_matches!(err.kind(), ErrorKind::CannotIndex);
     assert_matches!(
         err.context(),
@@ -120,7 +120,7 @@ fn no_required_field() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "#{ y: 2 }");
+    assert_eq!(err.main_location().span(code), "#{ y: 2 }");
     assert_eq!(err.location(), [fn_arg(0)]);
     assert_matches!(
         err.kind(),
@@ -142,7 +142,7 @@ fn incompatible_field_types() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "#{ x: (1, 2) }");
+    assert_eq!(err.main_location().span(code), "#{ x: (1, 2) }");
     assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("x")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
@@ -160,7 +160,7 @@ fn incompatible_field_types_via_accesses() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "!obj.x");
+    assert_eq!(err.main_location().span(code), "!obj.x");
     assert_eq!(err.location(), []);
     assert_matches!(err.context(), ErrorContext::UnaryOp(_));
     assert_matches!(
@@ -181,7 +181,7 @@ fn incompatible_field_types_via_fn() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "obj");
+    assert_eq!(err.main_location().span(code), "obj");
     assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("x")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
@@ -200,7 +200,7 @@ fn incompatible_fields_via_constraints_for_concrete_object() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "#{ x: 1, y: || 2 }");
+    assert_eq!(err.main_location().span(code), "#{ x: 1, y: || 2 }");
     assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("y")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
@@ -220,7 +220,7 @@ fn incompatible_fields_via_constraints_for_object_constraint() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "(obj.run)()");
+    assert_eq!(err.main_location().span(code), "(obj.run)()");
     assert_eq!(err.location(), []);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
@@ -240,7 +240,7 @@ fn incompatible_fields_via_constraints_for_object_constraint_rev() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "obj");
+    assert_eq!(err.main_location().span(code), "obj");
     assert_eq!(err.location(), [fn_arg(0), ErrorLocation::from("run")]);
     assert_matches!(err.context(), ErrorContext::FnCall { .. });
     assert_matches!(
@@ -347,8 +347,8 @@ fn repeated_field_in_object_initialization() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 15);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 15);
     assert_matches!(err.kind(), ErrorKind::RepeatedField(field) if field == "x");
 }
 
@@ -361,7 +361,7 @@ fn repeated_field_in_object_destructure() {
         .unwrap_err()
         .single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(err.main_span().location_offset(), 5);
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.main_location().location_offset(), 5);
     assert_matches!(err.kind(), ErrorKind::RepeatedField(field) if field == "x");
 }

--- a/typing/tests/integration/errors/recovery.rs
+++ b/typing/tests/integration/errors/recovery.rs
@@ -28,8 +28,8 @@ fn vars_are_not_assigned_beyond_first_error() {
     assert_eq!(errors.first_failing_statement(), 1);
 
     let err = errors.single();
-    assert_eq!(*err.main_span().fragment(), "x");
-    assert_eq!(*err.root_span().fragment(), "x.map(x)");
+    assert_eq!(err.main_location().span(code), "x");
+    assert_eq!(err.root_location().span(code), "x.map(x)");
     assert_matches!(err.kind(), ErrorKind::TypeMismatch(..));
     assert_eq!(type_env["x"], Type::slice(Type::NUM, 2));
     assert!(type_env.get("y").is_none());
@@ -71,7 +71,7 @@ fn vars_are_not_redefined_beyond_first_error() {
     assert_eq!(errors.first_failing_statement(), 1);
 
     let err = errors.single();
-    assert_eq!(*err.main_span().fragment(), "x");
+    assert_eq!(err.main_location().span(code), "x");
     assert_matches!(err.kind(), ErrorKind::TypeMismatch(..));
     assert_eq!(type_env["x"], Type::slice(Type::NUM, 2));
 }
@@ -88,7 +88,7 @@ fn vars_are_not_assigned_beyond_first_error_in_expr() {
     type_env.insert("map", Prelude::Map);
     let err = type_env.process_statements(&block).unwrap_err().single();
 
-    assert_eq!(*err.main_span().fragment(), "x");
+    assert_eq!(err.main_location().span(code), "x");
     assert_matches!(err.kind(), ErrorKind::TypeMismatch(..));
     assert_eq!(type_env["x"], Type::slice(Type::NUM, 2));
     assert!(type_env.get("y").is_none());
@@ -108,8 +108,8 @@ fn errors_in_inner_scopes_are_handled_adequately() {
     assert_eq!(errors.first_failing_statement(), 1);
 
     let err = errors.single();
-    assert_eq!(*err.main_span().fragment(), "bogus");
-    assert_eq!(*err.root_span().fragment(), "x.map(bogus)");
+    assert_eq!(err.main_location().span(code), "bogus");
+    assert_eq!(err.root_location().span(code), "x.map(bogus)");
     assert_matches!(err.kind(), ErrorKind::TypeMismatch(..));
     assert_eq!(type_env["x"], Type::slice(Type::NUM, 2));
     assert!(type_env.get("y").is_none());
@@ -130,7 +130,7 @@ fn errors_in_functions_are_handled_adequately() {
     assert_eq!(errors.first_failing_statement(), 1);
 
     let err = errors.single();
-    assert_eq!(*err.main_span().fragment(), "bogus");
+    assert_eq!(err.main_location().span(code), "bogus");
     assert_matches!(err.kind(), ErrorKind::TypeMismatch(..));
     assert_eq!(type_env["x"], Type::slice(Type::NUM, 2));
     assert!(type_env.get("y").is_none());

--- a/typing/tests/integration/examples/mod.rs
+++ b/typing/tests/integration/examples/mod.rs
@@ -294,14 +294,14 @@ fn schnorr_signatures() {
 #[test]
 fn schnorr_signatures_error() {
     let bogus_code = SCHNORR_CODE.replace("s: r - self * e", "s: R - self * e");
-    let code = U64Grammar::parse_statements(bogus_code.as_str()).unwrap();
+    let block = U64Grammar::parse_statements(bogus_code.as_str()).unwrap();
     let errors = prepare_env()
-        .process_with_arithmetic(&GroupArithmetic, &code)
+        .process_with_arithmetic(&GroupArithmetic, &block)
         .unwrap_err();
 
     assert_eq!(errors.len(), 1);
     let err = errors.into_iter().next().unwrap();
-    assert_eq!(*err.main_span().fragment(), "R");
+    assert_eq!(err.main_location().span(&bogus_code), "R");
     assert_eq!(
         err.kind().to_string(),
         "Type `Ge` is not assignable to type `Sc`"

--- a/typing/tests/integration/examples/mod.rs
+++ b/typing/tests/integration/examples/mod.rs
@@ -9,7 +9,7 @@ use arithmetic_typing::{
         Substitutions, TypeArithmetic, UnaryOpContext, WithBoolean,
     },
     defs::{Assertions, Prelude},
-    error::{ErrorLocation, OpErrors},
+    error::{ErrorPathFragment, OpErrors},
     visit::Visit,
     Annotated, DynConstraints, Function, PrimitiveType, Type, TypeEnvironment, UnknownLen,
 };
@@ -188,8 +188,8 @@ impl TypeArithmetic<GroupPrim> for GroupArithmetic {
 
         match context.op {
             BinaryOp::Add | BinaryOp::Sub => {
-                substitutions.unify(&SC, &context.lhs, errors.with_location(ErrorLocation::Lhs));
-                substitutions.unify(&SC, &context.rhs, errors.with_location(ErrorLocation::Rhs));
+                substitutions.unify(&SC, &context.lhs, errors.join_path(ErrorPathFragment::Lhs));
+                substitutions.unify(&SC, &context.rhs, errors.join_path(ErrorPathFragment::Rhs));
                 SC
             }
 
@@ -204,12 +204,12 @@ impl TypeArithmetic<GroupPrim> for GroupArithmetic {
                         substitutions.unify(
                             &SC,
                             &context.lhs,
-                            errors.with_location(ErrorLocation::Lhs),
+                            errors.join_path(ErrorPathFragment::Lhs),
                         );
                         substitutions.unify(
                             &SC,
                             &context.rhs,
-                            errors.with_location(ErrorLocation::Rhs),
+                            errors.join_path(ErrorPathFragment::Rhs),
                         );
                         SC
                     }
@@ -217,21 +217,21 @@ impl TypeArithmetic<GroupPrim> for GroupArithmetic {
                         substitutions.unify(
                             &GE,
                             &context.lhs,
-                            errors.with_location(ErrorLocation::Lhs),
+                            errors.join_path(ErrorPathFragment::Lhs),
                         );
                         substitutions.unify(
                             &GE,
                             &context.rhs,
-                            errors.with_location(ErrorLocation::Rhs),
+                            errors.join_path(ErrorPathFragment::Rhs),
                         );
                         GE
                     }
                     _ => {
                         MulOperand
-                            .visitor(substitutions, errors.with_location(ErrorLocation::Lhs))
+                            .visitor(substitutions, errors.join_path(ErrorPathFragment::Lhs))
                             .visit_type(&context.lhs);
                         MulOperand
-                            .visitor(substitutions, errors.with_location(ErrorLocation::Rhs))
+                            .visitor(substitutions, errors.join_path(ErrorPathFragment::Rhs))
                             .visit_type(&context.rhs);
                         substitutions.unify(&context.lhs, &context.rhs, errors);
                         context.lhs.clone()

--- a/typing/tests/integration/main.rs
+++ b/typing/tests/integration/main.rs
@@ -19,12 +19,12 @@ mod object;
 
 type F32Grammar = Annotated<NumGrammar<f32>>;
 
-trait ErrorsExt<'a, Prim: PrimitiveType> {
-    fn single(self) -> Error<'a, Prim>;
+trait ErrorsExt<Prim: PrimitiveType> {
+    fn single(self) -> Error<Prim>;
 }
 
-impl<'a, Prim: PrimitiveType> ErrorsExt<'a, Prim> for Errors<'a, Prim> {
-    fn single(self) -> Error<'a, Prim> {
+impl<Prim: PrimitiveType> ErrorsExt<Prim> for Errors<Prim> {
+    fn single(self) -> Error<Prim> {
         if self.len() == 1 {
             self.into_iter().next().unwrap()
         } else {


### PR DESCRIPTION
## What?

Removes a redundant lifetime param from the `Error` type. Renames `ErrorLocation` to `ErrorPathFragment` to distinguish it from `Location`.

## Why?

- Allows boxing `Error`, converting it to `anyhow::Error` etc.
- Makes error handling more idiomatic.