### PR TITLE
Fix / update crate docs

### DIFF
--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -602,9 +602,6 @@ impl Backtrace {
 }
 
 /// Error with the associated backtrace.
-///
-/// Use the [`StripCode`] implementation to convert this to the `'static` lifetime, e.g.,
-/// before boxing it into `Box<dyn std::error::Error>` or `anyhow::Error`.
 #[derive(Debug)]
 pub struct ErrorWithBacktrace {
     inner: Error,

--- a/eval/src/exec/mod.rs
+++ b/eval/src/exec/mod.rs
@@ -38,8 +38,6 @@ mod registers;
 /// for such cases.
 ///
 /// `ExecutableModule`s are generic with respect to the primitive value type, just like [`Value`].
-/// The lifetime of a module depends on the lifetime of the code, but this dependency
-/// can be eliminated via [`StripCode`] implementation.
 ///
 /// # Examples
 ///

--- a/typing/README.md
+++ b/typing/README.md
@@ -5,7 +5,8 @@
 ![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg)
 ![no_std supported](https://img.shields.io/badge/no__std-tested-green.svg)
 
-**Links:** [![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/arithmetic-parser/arithmetic_typing/)
+**Links:** [![Docs on docs.rs](https://img.shields.io/docsrs/arithmetic-typing)](https://docs.rs/arithmetic-typing/)
+[![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/arithmetic-parser/arithmetic_typing/)
 
 Hindley–Milner type inference for arithmetic expressions parsed
 by the [`arithmetic-parser`] crate.


### PR DESCRIPTION
## What?

- Removes obsolete lifetime mentions from crate docs.
- Adds a `docs.rs` badge to the typing crate readme.

## Why?

To maintain docs quality.